### PR TITLE
Flip message types for persona role in conversation history

### DIFF
--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -556,3 +556,52 @@ class TestClaudeLLM:
 
         # Should have: SystemMessage + current message only
         assert len(messages) == 2
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
+    @patch("llm_clients.claude_llm.ChatAnthropic")
+    async def test_generate_response_with_persona_role_flips_types(
+        self, mock_chat_anthropic
+    ):
+        """Test that persona role flips message types in conversation history."""
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Persona response"
+        mock_response.id = "msg_persona"
+        mock_response.response_metadata = {}
+
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_anthropic.return_value = mock_llm
+
+        # Persona system prompt should trigger message type flipping
+        persona_prompt = "You are roleplaying as a human user"
+        llm = ClaudeLLM(name="TestClaude", system_prompt=persona_prompt)
+
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        response = await llm.generate_response(conversation_history=history)
+
+        assert response == "Persona response"
+
+        # Verify message types are flipped for persona role
+        call_args = mock_llm.ainvoke.call_args
+        messages = call_args[0][0]
+
+        # Should have: SystemMessage + 3 history messages
+        assert len(messages) == 4
+        assert isinstance(messages[0], SystemMessage)
+        # Turn 1 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].content == "Hello"
+        # Turn 2 (provider, even) should be HumanMessage when persona role
+        assert isinstance(messages[2], HumanMessage)
+        assert messages[2].content == "Hi there"
+        # Turn 3 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[3], AIMessage)
+        assert messages[3].content == "How are you?"

--- a/tests/unit/llm_clients/test_gemini_llm.py
+++ b/tests/unit/llm_clients/test_gemini_llm.py
@@ -551,3 +551,52 @@ class TestGeminiLLM:
         call_args = mock_llm.ainvoke.call_args
         messages = call_args[0][0]
         assert len(messages) == 2
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.gemini_llm.Config.GOOGLE_API_KEY", "test-key")
+    @patch("llm_clients.gemini_llm.ChatGoogleGenerativeAI")
+    async def test_generate_response_with_persona_role_flips_types(
+        self, mock_chat_gemini
+    ):
+        """Test that persona role flips message types in conversation history."""
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Persona response"
+        mock_response.id = "gemini-persona"
+        mock_response.response_metadata = {}
+
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_gemini.return_value = mock_llm
+
+        # Persona system prompt should trigger message type flipping
+        persona_prompt = "You are roleplaying as a human user"
+        llm = GeminiLLM(name="TestGemini", system_prompt=persona_prompt)
+
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        response = await llm.generate_response(conversation_history=history)
+
+        assert response == "Persona response"
+
+        # Verify message types are flipped for persona role
+        call_args = mock_llm.ainvoke.call_args
+        messages = call_args[0][0]
+
+        # Should have: SystemMessage + 3 history messages
+        assert len(messages) == 4
+        assert isinstance(messages[0], SystemMessage)
+        # Turn 1 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].content == "Hello"
+        # Turn 2 (provider, even) should be HumanMessage when persona role
+        assert isinstance(messages[2], HumanMessage)
+        assert messages[2].content == "Hi there"
+        # Turn 3 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[3], AIMessage)
+        assert messages[3].content == "How are you?"

--- a/tests/unit/llm_clients/test_llama_llm.py
+++ b/tests/unit/llm_clients/test_llama_llm.py
@@ -441,3 +441,38 @@ class TestLlamaLLMConversationHistory:
         # Should just have current message
         call_args = mock_instance.invoke.call_args[0][0]
         assert call_args == "Human: Test\n\nAssistant:"
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.llama_llm.Ollama")
+    async def test_generate_response_with_persona_role_flips_types(self, mock_ollama):
+        """Test that persona role flips message types in conversation history."""
+        from llm_clients.llama_llm import LlamaLLM
+
+        mock_instance = MagicMock()
+        mock_instance.invoke.return_value = "Persona response"
+        mock_ollama.return_value = mock_instance
+
+        # Persona system prompt should trigger message type flipping
+        persona_prompt = "You are roleplaying as a human user"
+        llm = LlamaLLM(name="test-llama", system_prompt=persona_prompt)
+
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        response = await llm.generate_response(conversation_history=history)
+
+        assert response == "Persona response"
+
+        # Verify message types are flipped for persona role
+        call_args = mock_instance.invoke.call_args[0][0]
+        assert "System: You are roleplaying as a human user" in call_args
+        # Turn 1 (persona, odd) should be Assistant when persona role
+        assert "Assistant: Hello" in call_args
+        # Turn 2 (provider, even) should be Human when persona role
+        assert "Human: Hi there" in call_args
+        # Turn 3 (persona, odd) should be Assistant when persona role
+        assert "Assistant: How are you?" in call_args
+        assert "Assistant:" in call_args

--- a/tests/unit/llm_clients/test_openai_llm.py
+++ b/tests/unit/llm_clients/test_openai_llm.py
@@ -519,3 +519,52 @@ class TestOpenAILLM:
         call_args = mock_llm.ainvoke.call_args
         messages = call_args[0][0]
         assert len(messages) == 2
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.openai_llm.Config.OPENAI_API_KEY", "test-key")
+    @patch("llm_clients.openai_llm.ChatOpenAI")
+    async def test_generate_response_with_persona_role_flips_types(
+        self, mock_chat_openai
+    ):
+        """Test that persona role flips message types in conversation history."""
+        from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
+
+        mock_llm = MagicMock()
+        mock_response = MagicMock()
+        mock_response.text = "Persona response"
+        mock_response.id = "chatcmpl-persona"
+        mock_response.response_metadata = {}
+
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_openai.return_value = mock_llm
+
+        # Persona system prompt should trigger message type flipping
+        persona_prompt = "You are roleplaying as a human user"
+        llm = OpenAILLM(name="TestOpenAI", system_prompt=persona_prompt)
+
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        response = await llm.generate_response(conversation_history=history)
+
+        assert response == "Persona response"
+
+        # Verify message types are flipped for persona role
+        call_args = mock_llm.ainvoke.call_args
+        messages = call_args[0][0]
+
+        # Should have: SystemMessage + 3 history messages
+        assert len(messages) == 4
+        assert isinstance(messages[0], SystemMessage)
+        # Turn 1 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].content == "Hello"
+        # Turn 2 (provider, even) should be HumanMessage when persona role
+        assert isinstance(messages[2], HumanMessage)
+        assert messages[2].content == "Hi there"
+        # Turn 3 (persona, odd) should be AIMessage when persona role
+        assert isinstance(messages[3], AIMessage)
+        assert messages[3].content == "How are you?"

--- a/tests/unit/utils/test_conversation_utils.py
+++ b/tests/unit/utils/test_conversation_utils.py
@@ -187,6 +187,85 @@ class TestBuildLangchainMessages:
         assert isinstance(messages[1], HumanMessage)
         assert messages[1].content == "Are you there?"
 
+    def test_build_messages_with_persona_role_flips_types(self):
+        """Test that persona role flips message types correctly."""
+        # When LLM is playing persona, persona turns should be AIMessage
+        # and provider turns should be HumanMessage
+        persona_system_prompt = "You are roleplaying as a human user"
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello, I need help"},
+            {"turn": 2, "speaker": "provider", "response": "How can I help you?"},
+            {"turn": 3, "speaker": "persona", "response": "I'm feeling anxious"},
+            {"turn": 4, "speaker": "provider", "response": "Tell me more"},
+        ]
+
+        messages = build_langchain_messages(
+            conversation_history=history, system_prompt=persona_system_prompt
+        )
+
+        assert len(messages) == 4
+        # Turn 1 (odd, persona) should be AIMessage when persona role
+        assert isinstance(messages[0], AIMessage)
+        assert messages[0].content == "Hello, I need help"
+        # Turn 2 (even, provider) should be HumanMessage when persona role
+        assert isinstance(messages[1], HumanMessage)
+        assert messages[1].content == "How can I help you?"
+        # Turn 3 (odd, persona) should be AIMessage when persona role
+        assert isinstance(messages[2], AIMessage)
+        assert messages[2].content == "I'm feeling anxious"
+        # Turn 4 (even, provider) should be HumanMessage when persona role
+        assert isinstance(messages[3], HumanMessage)
+        assert messages[3].content == "Tell me more"
+
+    def test_build_messages_without_persona_role_keeps_default(self):
+        """Test that non-persona role keeps default message types."""
+        # When LLM is NOT playing persona, default behavior applies
+        provider_system_prompt = "You are a helpful therapist"
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        messages = build_langchain_messages(
+            conversation_history=history, system_prompt=provider_system_prompt
+        )
+
+        assert len(messages) == 3
+        # Turn 1 (odd, persona) should be HumanMessage (default)
+        assert isinstance(messages[0], HumanMessage)
+        assert messages[0].content == "Hello"
+        # Turn 2 (even, provider) should be AIMessage (default)
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].content == "Hi there"
+        # Turn 3 (odd, persona) should be HumanMessage (default)
+        assert isinstance(messages[2], HumanMessage)
+        assert messages[2].content == "How are you?"
+
+    def test_build_messages_persona_with_turn_0(self):
+        """Test persona role with turn 0 (initial message)."""
+        persona_system_prompt = "You are roleplaying as a human user"
+        history = [
+            {"turn": 0, "speaker": "system", "response": "Initial message"},
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi"},
+        ]
+
+        messages = build_langchain_messages(
+            conversation_history=history, system_prompt=persona_system_prompt
+        )
+
+        assert len(messages) == 3
+        # Turn 0 should always be HumanMessage regardless of role
+        assert isinstance(messages[0], HumanMessage)
+        assert messages[0].content == "Initial message"
+        # Turn 1 (persona) should be AIMessage when persona role
+        assert isinstance(messages[1], AIMessage)
+        assert messages[1].content == "Hello"
+        # Turn 2 (provider) should be HumanMessage when persona role
+        assert isinstance(messages[2], HumanMessage)
+        assert messages[2].content == "Hi"
+
 
 class TestFormatConversationAsString:
     """Test format_conversation_as_string function."""
@@ -284,3 +363,27 @@ class TestFormatConversationAsString:
         )
 
         assert result == ""
+
+    def test_format_with_persona_role_flips_types(self):
+        """Test that persona role flips message types in string format."""
+        persona_system_prompt = "You are roleplaying as a human user"
+        history = [
+            {"turn": 1, "speaker": "persona", "response": "Hello"},
+            {"turn": 2, "speaker": "provider", "response": "Hi there"},
+            {"turn": 3, "speaker": "persona", "response": "How are you?"},
+        ]
+
+        result = format_conversation_as_string(
+            conversation_history=history, system_prompt=persona_system_prompt
+        )
+
+        # When persona role, persona turns (odd) should be Assistant,
+        # provider turns (even) should be Human
+        expected = (
+            "System: You are roleplaying as a human user\n\n"
+            "Assistant: Hello\n\n"
+            "Human: Hi there\n\n"
+            "Assistant: How are you?\n\n"
+            "Assistant:"
+        )
+        assert result == expected

--- a/utils/conversation_utils.py
+++ b/utils/conversation_utils.py
@@ -112,8 +112,14 @@ def build_langchain_messages(
 
     Uses turn indices to determine message type since speaker names can be custom:
     - Turn 0: Initial message (HumanMessage)
+
+    When LLM is playing persona role (is_persona=True):
+    - Odd turns (1, 3, 5...): Persona responses (AIMessage)
+    - Even turns (2, 4, 6...): Provider responses (HumanMessage)
+
+    When LLM is playing provider role (is_persona=False):
     - Odd turns (1, 3, 5...): Persona responses (HumanMessage)
-    - Even turns (2, 4, 6...): Agent responses (AIMessage)
+    - Even turns (2, 4, 6...): Provider responses (AIMessage)
 
     IMPORTANT: This assumes persona always speaks first (see ConversationSimulator
     line 90-92). If the speaker order changes, this logic must be updated.
@@ -122,25 +128,16 @@ def build_langchain_messages(
         conversation_history: Optional list of previous conversation turns.
             Each turn is a dict with keys: 'turn', 'speaker', 'response'.
             Turn 0 contains the initial message with speaker="system".
-        system_prompt: Optional system prompt to check if this is a persona.
-            If provided and contains "roleplaying as a human user", a role
-            reminder will be automatically injected before conversation history
-            (but only for turns >= 1, not for turn 0).
+        system_prompt: Optional system prompt to detect persona role.
+            If provided and contains "roleplaying as a human user", message
+            types will be flipped (persona turns become AIMessage, provider
+            turns become HumanMessage).
 
     Returns:
         List of LangChain message objects (HumanMessage, AIMessage)
     """
     messages = []
-
-    # Auto-detect persona and add role reminder if needed
-    # Only add role reminder if we have real conversation history (turn >= 1)
     is_persona = system_prompt and "roleplaying as a human user" in system_prompt
-    has_real_history = conversation_history and any(
-        turn.get("turn", 0) >= 1 for turn in conversation_history
-    )
-    if is_persona and has_real_history:
-        debug_print("[DEBUG] Adding role reminder message for persona")
-        messages.append(HumanMessage(content=build_persona_role_reminder()))
 
     # Add conversation history if provided
     if conversation_history:
@@ -160,16 +157,30 @@ def build_langchain_messages(
                 messages.append(HumanMessage(content=text))
                 continue
 
-            # Handle regular turns (1, 2, 3, ...)
-            # Odd turns (1, 3, 5...) = persona (HumanMessage)
-            # Even turns (2, 4, 6...) = agent (AIMessage)
-            msg_type = "HumanMessage" if turn_number % 2 == 1 else "AIMessage"
+            # Determine message type based on turn number and role
+            # Persona speaks on odd turns (1, 3, 5...), provider on even (2, 4, 6...)
+            is_persona_turn = turn_number % 2 == 1
+
+            # Flip message types when LLM is playing persona role
+            if is_persona:
+                # Persona responses are AIMessage, provider inputs are HumanMessage
+                message = (
+                    AIMessage(content=text)
+                    if is_persona_turn
+                    else HumanMessage(content=text)
+                )
+            else:
+                # Persona inputs are HumanMessage, provider responses are AIMessage
+                message = (
+                    HumanMessage(content=text)
+                    if is_persona_turn
+                    else AIMessage(content=text)
+                )
+
+            msg_type = type(message).__name__
             preview = text[:50] + "..." if len(text) > 50 else text
             debug_print(f"  Turn {turn_number} -> {msg_type}: {preview}")
-            if turn_number % 2 == 1:
-                messages.append(HumanMessage(content=text))
-            else:
-                messages.append(AIMessage(content=text))
+            messages.append(message)
 
     return messages
 


### PR DESCRIPTION
## Description
This PR implements automatic message type flipping when an LLM is playing the persona role in a conversation. When it is the persona LLM's turn, the message types are automatically reversed so that persona turns are treated as `AIMessage` (the persona is responding) and provider turns are treated as `HumanMessage` (input to the persona).