### PR TITLE
Refactor: remove commented code and Config defaults for LLM parameters

### DIFF
--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -37,8 +37,6 @@ class ClaudeLLM(JudgeLLM):
         llm_params = {
             "anthropic_api_key": Config.ANTHROPIC_API_KEY,
             "model": self.model_name,
-            # "temperature": config.get("temperature", 0.7),
-            # "max_tokens": config.get("max_tokens", 1000)
         }
 
         # Override with any provided kwargs

--- a/llm_clients/config.py
+++ b/llm_clients/config.py
@@ -1,3 +1,13 @@
+"""Configuration module for LLM clients.
+
+Design Philosophy:
+- Model-specific parameters (temperature, max_tokens) should be passed at
+  runtime via CLI
+- Config class only provides fallback model names and API key access
+- All LLM implementations rely on runtime parameters or LangChain/provider
+  defaults
+"""
+
 import os
 from typing import Any, Dict
 
@@ -7,94 +17,51 @@ load_dotenv()
 
 
 class Config:
+    """Configuration for LLM clients.
+
+    Provides API key access and fallback model names.
+    Runtime parameters should be passed via CLI arguments.
+    """
+
     # API Keys
     ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
     OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
     GOOGLE_API_KEY = os.getenv("GOOGLE_API_KEY")  # For Gemini
     # Note: Llama via Ollama doesn't require an API key
 
-    # Default model configurations
-    MODELS_CONFIG = {
-        "claude-3-5-sonnet-20241022": {
-            "provider": "anthropic",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "claude-3-opus-20240229": {
-            "provider": "anthropic",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "claude-3-sonnet-20240229": {
-            "provider": "anthropic",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "claude-3-haiku-20240307": {
-            "provider": "anthropic",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "gpt-4": {"provider": "openai", "temperature": 0.7, "max_tokens": 1000},
-        "gpt-4-turbo": {"provider": "openai", "temperature": 0.7, "max_tokens": 1000},
-        "gpt-3.5-turbo": {"provider": "openai", "temperature": 0.7, "max_tokens": 1000},
-        "gemini-1.5-pro": {
-            "provider": "google",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "gemini-1.5-flash": {
-            "provider": "google",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        },
-        "gemini-pro": {"provider": "google", "temperature": 0.7, "max_tokens": 1000},
-        "llama2:7b": {
-            "provider": "ollama",
-            "temperature": 0.7,
-            "base_url": "http://localhost:11434",
-        },
-        "llama2:13b": {
-            "provider": "ollama",
-            "temperature": 0.7,
-            "base_url": "http://localhost:11434",
-        },
-        "llama3:8b": {
-            "provider": "ollama",
-            "temperature": 0.7,
-            "base_url": "http://localhost:11434",
-        },
-        "llama3:70b": {
-            "provider": "ollama",
-            "temperature": 0.7,
-            "base_url": "http://localhost:11434",
-        },
-    }
-
     @classmethod
     def get_claude_config(cls) -> Dict[str, Any]:
-        """Legacy method for backward compatibility."""
-        return {
-            "model": "claude-3-5-sonnet-20241022",
-            "temperature": 0.7,
-            "max_tokens": 1000,
-        }
+        """Get default Claude model name.
+
+        Returns only the model name. Runtime parameters (temperature, max_tokens)
+        should be passed explicitly via CLI arguments.
+        """
+        return {"model": "claude-3-5-sonnet-20241022"}
 
     @classmethod
     def get_openai_config(cls) -> Dict[str, Any]:
-        """Get default OpenAI configuration."""
-        return {"model": "gpt-4", "temperature": 0.7, "max_tokens": 1000}
+        """Get default OpenAI model name.
+
+        Returns only the model name. Runtime parameters (temperature, max_tokens)
+        should be passed explicitly via CLI arguments.
+        """
+        return {"model": "gpt-4"}
 
     @classmethod
     def get_gemini_config(cls) -> Dict[str, Any]:
-        """Get default Gemini configuration."""
-        return {"model": "gemini-1.5-pro", "temperature": 0.7, "max_tokens": 1000}
+        """Get default Gemini model name.
+
+        Returns only the model name. Runtime parameters (temperature, max_tokens)
+        should be passed explicitly via CLI arguments.
+        """
+        return {"model": "gemini-1.5-pro"}
 
     @classmethod
     def get_llama_config(cls) -> Dict[str, Any]:
-        """Get default Llama configuration."""
-        return {
-            "model": "llama3:8b",
-            "temperature": 0.7,
-            "base_url": "http://localhost:11434",
-        }
+        """Get default Llama model name.
+
+        Returns only the model name. Runtime parameters (temperature, max_tokens)
+        should be passed explicitly via CLI arguments. The base_url for Ollama
+        is hardcoded in llama_llm.py for connectivity purposes.
+        """
+        return {"model": "llama3:8b"}

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -37,8 +37,6 @@ class GeminiLLM(JudgeLLM):
         llm_params = {
             "google_api_key": Config.GOOGLE_API_KEY,
             "model": self.model_name,
-            # "temperature": config.get("temperature", 0.7),
-            # "max_tokens": config.get("max_tokens", 1000)
         }
 
         # Override with any provided kwargs

--- a/llm_clients/llama_llm.py
+++ b/llm_clients/llama_llm.py
@@ -29,13 +29,10 @@ class LlamaLLM(LLMInterface):
         self.model_name = model_name or Config.get_llama_config()["model"]
 
         # Get default config and allow kwargs to override
-        config = Config.get_llama_config()
+        # Note: base_url is kept as a default for Ollama connectivity
         llm_params = {
             "model": self.model_name,
-            "temperature": config.get("temperature", 0.7),
-            "base_url": config.get(
-                "base_url", "http://localhost:11434"
-            ),  # Default Ollama URL
+            "base_url": "http://localhost:11434",  # Default Ollama URL
         }
 
         # Override with any provided kwargs

--- a/llm_clients/openai_llm.py
+++ b/llm_clients/openai_llm.py
@@ -37,8 +37,6 @@ class OpenAILLM(JudgeLLM):
         llm_params = {
             "openai_api_key": Config.OPENAI_API_KEY,
             "model": self.model_name,
-            # "temperature": config.get("temperature", 0.7),
-            # "max_tokens": config.get("max_tokens", 1000)
         }
 
         # Override with any provided kwargs

--- a/tests/unit/llm_clients/test_config.py
+++ b/tests/unit/llm_clients/test_config.py
@@ -17,72 +17,27 @@ class TestConfig:
         assert hasattr(Config, "OPENAI_API_KEY")
         assert hasattr(Config, "GOOGLE_API_KEY")
 
-    def test_models_config_structure(self):
-        """Test that MODELS_CONFIG has expected structure."""
-        assert isinstance(Config.MODELS_CONFIG, dict)
-        assert len(Config.MODELS_CONFIG) > 0
-
-        # Check a few known models
-        assert "claude-3-5-sonnet-20241022" in Config.MODELS_CONFIG
-        assert "gpt-4" in Config.MODELS_CONFIG
-        assert "gemini-1.5-pro" in Config.MODELS_CONFIG
-        assert "llama3:8b" in Config.MODELS_CONFIG
-
-    def test_claude_config_has_required_fields(self):
-        """Test that Claude config entries have required fields."""
-        claude_config = Config.MODELS_CONFIG["claude-3-5-sonnet-20241022"]
-        assert "provider" in claude_config
-        assert claude_config["provider"] == "anthropic"
-        assert "temperature" in claude_config
-        assert "max_tokens" in claude_config
-
-    def test_openai_config_has_required_fields(self):
-        """Test that OpenAI config entries have required fields."""
-        openai_config = Config.MODELS_CONFIG["gpt-4"]
-        assert "provider" in openai_config
-        assert openai_config["provider"] == "openai"
-        assert "temperature" in openai_config
-        assert "max_tokens" in openai_config
-
-    def test_gemini_config_has_required_fields(self):
-        """Test that Gemini config entries have required fields."""
-        gemini_config = Config.MODELS_CONFIG["gemini-1.5-pro"]
-        assert "provider" in gemini_config
-        assert gemini_config["provider"] == "google"
-        assert "temperature" in gemini_config
-        assert "max_tokens" in gemini_config
-
-    def test_llama_config_has_required_fields(self):
-        """Test that Llama config entries have required fields."""
-        llama_config = Config.MODELS_CONFIG["llama3:8b"]
-        assert "provider" in llama_config
-        assert llama_config["provider"] == "ollama"
-        assert "temperature" in llama_config
-        assert "base_url" in llama_config
-
     def test_get_claude_config(self):
-        """Test get_claude_config returns expected structure (line 77)."""
+        """Test get_claude_config returns expected structure."""
         config = Config.get_claude_config()
 
         assert isinstance(config, dict)
         assert "model" in config
         assert config["model"] == "claude-3-5-sonnet-20241022"
-        assert "temperature" in config
-        assert config["temperature"] == 0.7
-        assert "max_tokens" in config
-        assert config["max_tokens"] == 1000
+        # Temperature and max_tokens should NOT be in config
+        assert "temperature" not in config
+        assert "max_tokens" not in config
 
     def test_get_openai_config(self):
-        """Test get_openai_config returns expected structure (line 86)."""
+        """Test get_openai_config returns expected structure."""
         config = Config.get_openai_config()
 
         assert isinstance(config, dict)
         assert "model" in config
         assert config["model"] == "gpt-4"
-        assert "temperature" in config
-        assert config["temperature"] == 0.7
-        assert "max_tokens" in config
-        assert config["max_tokens"] == 1000
+        # Temperature and max_tokens should NOT be in config
+        assert "temperature" not in config
+        assert "max_tokens" not in config
 
     def test_get_gemini_config(self):
         """Test get_gemini_config returns expected structure."""
@@ -91,10 +46,9 @@ class TestConfig:
         assert isinstance(config, dict)
         assert "model" in config
         assert config["model"] == "gemini-1.5-pro"
-        assert "temperature" in config
-        assert config["temperature"] == 0.7
-        assert "max_tokens" in config
-        assert config["max_tokens"] == 1000
+        # Temperature and max_tokens should NOT be in config
+        assert "temperature" not in config
+        assert "max_tokens" not in config
 
     def test_get_llama_config(self):
         """Test get_llama_config returns expected structure."""
@@ -103,19 +57,9 @@ class TestConfig:
         assert isinstance(config, dict)
         assert "model" in config
         assert config["model"] == "llama3:8b"
-        assert "temperature" in config
-        assert config["temperature"] == 0.7
-        assert "base_url" in config
-        assert config["base_url"] == "http://localhost:11434"
-
-    def test_config_defaults_are_consistent(self):
-        """Test that default temperature and max_tokens are consistent."""
-        for model_name, model_config in Config.MODELS_CONFIG.items():
-            assert "provider" in model_config
-            assert "temperature" in model_config
-            # Ollama models don't require max_tokens
-            if model_config["provider"] != "ollama":
-                assert "max_tokens" in model_config
+        # Temperature and base_url should NOT be in config
+        assert "temperature" not in config
+        assert "base_url" not in config
 
     @patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-anthropic-key"})
     def test_anthropic_api_key_from_env(self):

--- a/tests/unit/llm_clients/test_llama_llm.py
+++ b/tests/unit/llm_clients/test_llama_llm.py
@@ -21,9 +21,11 @@ class TestLlamaLLMInit:
         call_kwargs = mock_ollama.call_args[1]
 
         assert "model" in call_kwargs
-        assert "temperature" in call_kwargs
+        # base_url has a hardcoded default for Ollama connectivity
         assert "base_url" in call_kwargs
         assert call_kwargs["base_url"] == "http://localhost:11434"
+        # temperature should NOT be set by default
+        assert "temperature" not in call_kwargs
 
     @patch("llm_clients.llama_llm.Ollama")
     def test_init_with_custom_model_name(self, mock_ollama):


### PR DESCRIPTION
Remove all commented-out temperature/max_tokens code and eliminate default parameter values from Config class. All LLM implementations now rely exclusively on runtime parameters passed via CLI arguments or LangChain/provider defaults.

Changes:
- Remove commented temperature/max_tokens lines from Claude, OpenAI, Gemini implementations
- Remove MODELS_CONFIG dictionary from Config class
- Simplify all get_*_config() methods to return only model names
- Remove temperature default from Llama implementation (consistent with other providers)
- Keep base_url hardcoded in llama_llm.py for Ollama connectivity
- Update all tests to reflect new configuration structure

All 113 unit tests passing.