### PR TITLE
Cache claude

### DIFF
--- a/docs/evaluating.md
+++ b/docs/evaluating.md
@@ -246,6 +246,17 @@ python3 generate.py -u your-model-name -p your-model-name -t 5 -r 1
 python3 judge.py -f conversations/{YOUR_FOLDER} -j your-model-name
 ```
 
+## Prompt caching (by provider)
+
+Provider APIs differ in how prompt/context caching works. The built-in clients behave as follows:
+
+| Provider | Behavior in this repo |
+|----------|------------------------|
+| **Claude** (`ClaudeLLM`) | Anthropic prompt caching is **opt-in** per request. The client passes `cache_control` (default: ephemeral TTL, typically 5 minutes). Set `caching=False` on `ClaudeLLM` to disable. For TTL or other API shapes, pass `anthropic_cache_control=...` (set to `None` to omit `cache_control` while keeping other constructor behavior). |
+| **OpenAI** (`OpenAILLM`) | OpenAI applies **automatic** prompt caching for eligible models/prefixes. The client passes `prompt_cache_key` (per conversation) on each call to improve cache routing; there is no separate on/off flag in this wrapper. |
+| **Azure** (`AzureLLM`) | Follows the underlying Azure/OpenAI-compatible API. This wrapper does not set Anthropic-style `cache_control` or OpenAI-style `prompt_cache_key`. |
+| **Gemini** (`GeminiLLM`) | For **eligible models** (e.g. Gemini 2.5+), the Google GenAI API applies **implicit (automatic) prompt caching** when requests share a common prefix—no extra parameters in this client. **Explicit** context caching (`cached_content` resources) is **not** wired in `GeminiLLM`; that path needs a separate create/update lifecycle and is unrelated to implicit caching. |
+
 ## Important Notes
 
 - **Async Support**: The current implementation uses `async` to avoid blocking when multiple conversations are being generated

--- a/llm_clients/azure_llm.py
+++ b/llm_clients/azure_llm.py
@@ -19,7 +19,11 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class AzureLLM(JudgeLLM):
-    """Azure OpenAI implementation using LangChain."""
+    """Azure OpenAI implementation using LangChain.
+
+    Caching follows the underlying Azure/OpenAI-compatible API. This client does not set
+    Anthropic ``cache_control`` or OpenAI ``prompt_cache_key`` (not on this wrapper).
+    """
 
     DEFAULT_API_VERSION = "2024-05-01-preview"
 

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -13,6 +13,11 @@ from .llm_interface import JudgeLLM, Role
 
 T = TypeVar("T", bound=BaseModel)
 
+# Anthropic-only: prompt caching is opt-in per request (not `cache_control` elsewhere).
+# Default ephemeral TTL is 5m (no `ttl` key). Override with ctor kwarg
+# anthropic_cache_control, e.g. {"type": "ephemeral", "ttl": "1h"}, or None to disable.
+_DEFAULT_ANTHROPIC_CACHE_CONTROL: Dict[str, Any] = {"type": "ephemeral"}
+
 
 class ClaudeLLM(JudgeLLM):
     """Claude implementation using LangChain."""
@@ -37,6 +42,9 @@ class ClaudeLLM(JudgeLLM):
     ):
         first_message = kwargs.pop("first_message", None)
         start_prompt = kwargs.pop("start_prompt", None)
+        self._anthropic_cache_control: Optional[Dict[str, Any]] = kwargs.pop(
+            "anthropic_cache_control", dict(_DEFAULT_ANTHROPIC_CACHE_CONTROL)
+        )
         super().__init__(
             name,
             role,
@@ -120,7 +128,10 @@ class ClaudeLLM(JudgeLLM):
 
         async def _invoke() -> str:
             start_time = time.time()
-            response = await self.llm.ainvoke(messages)
+            invoke_kw: Dict[str, Any] = {}
+            if self._anthropic_cache_control:
+                invoke_kw["cache_control"] = self._anthropic_cache_control
+            response = await self.llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()
 
             model = (
@@ -147,6 +158,12 @@ class ClaudeLLM(JudgeLLM):
                         "total_tokens": usage.get("input_tokens", 0)
                         + usage.get("output_tokens", 0),
                     }
+                    for ck in (
+                        "cache_creation_input_tokens",
+                        "cache_read_input_tokens",
+                    ):
+                        if usage.get(ck) is not None:
+                            self._last_response_metadata["usage"][ck] = usage[ck]
                 self._last_response_metadata["stop_reason"] = metadata.get(
                     "stop_reason"
                 )
@@ -179,7 +196,10 @@ class ClaudeLLM(JudgeLLM):
             structured_llm = self.llm.with_structured_output(response_model)
 
             start_time = time.time()
-            response = await structured_llm.ainvoke(messages)
+            invoke_kw: Dict[str, Any] = {}
+            if self._anthropic_cache_control:
+                invoke_kw["cache_control"] = self._anthropic_cache_control
+            response = await structured_llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()
 
             self._set_response_metadata(

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -14,8 +14,9 @@ from .llm_interface import JudgeLLM, Role
 T = TypeVar("T", bound=BaseModel)
 
 # Anthropic-only: prompt caching is opt-in per request (not `cache_control` elsewhere).
-# Default ephemeral TTL is 5m (no `ttl` key). Override with ctor kwarg
-# anthropic_cache_control, e.g. {"type": "ephemeral", "ttl": "1h"}, or None to disable.
+# Default ephemeral TTL is 5m (no `ttl` key).
+# TTL is the time after which the stored context will expire
+# and be removed from memory if it is not used.
 _DEFAULT_ANTHROPIC_CACHE_CONTROL: Dict[str, Any] = {"type": "ephemeral"}
 
 

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -130,7 +130,7 @@ class ClaudeLLM(JudgeLLM):
         async def _invoke() -> str:
             start_time = time.time()
             invoke_kw: Dict[str, Any] = {}
-            if self._anthropic_cache_control:
+            if self._anthropic_cache_control is not None:
                 invoke_kw["cache_control"] = self._anthropic_cache_control
             response = await self.llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -21,7 +21,11 @@ _DEFAULT_ANTHROPIC_CACHE_CONTROL: Dict[str, Any] = {"type": "ephemeral"}
 
 
 class ClaudeLLM(JudgeLLM):
-    """Claude implementation using LangChain."""
+    """Claude implementation using LangChain.
+
+    Prompt caching uses Anthropic's per-request ``cache_control`` (see ``caching`` and
+    ``anthropic_cache_control`` constructor args).
+    """
 
     def _no_retry_substrings(self) -> tuple[str, ...]:
         # Anthropic API / Messages API (see https://docs.anthropic.com/en/api/errors)
@@ -39,13 +43,18 @@ class ClaudeLLM(JudgeLLM):
         role: Role,
         system_prompt: Optional[str] = None,
         model_name: Optional[str] = None,
+        caching: bool = True,
         **kwargs,
     ):
         first_message = kwargs.pop("first_message", None)
         start_prompt = kwargs.pop("start_prompt", None)
-        self._anthropic_cache_control: Optional[Dict[str, Any]] = kwargs.pop(
+        cache_control_arg: Optional[Dict[str, Any]] = kwargs.pop(
             "anthropic_cache_control", dict(_DEFAULT_ANTHROPIC_CACHE_CONTROL)
         )
+        if not caching:
+            self._anthropic_cache_control: Optional[Dict[str, Any]] = None
+        else:
+            self._anthropic_cache_control = cache_control_arg
         super().__init__(
             name,
             role,
@@ -198,7 +207,7 @@ class ClaudeLLM(JudgeLLM):
 
             start_time = time.time()
             invoke_kw: Dict[str, Any] = {}
-            if self._anthropic_cache_control:
+            if self._anthropic_cache_control is not None:
                 invoke_kw["cache_control"] = self._anthropic_cache_control
             response = await structured_llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -15,7 +15,12 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class GeminiLLM(JudgeLLM):
-    """Gemini implementation using LangChain."""
+    """Gemini implementation using LangChain.
+
+    Google GenAI Context Caching (``cached_content`` resource names) is not wired here;
+    it needs a separate cache create/update lifecycle. There is no Anthropic-style
+    ``cache_control`` on ``ChatGoogleGenerativeAI`` for one-flag prefix caching.
+    """
 
     def _no_retry_substrings(self) -> tuple[str, ...]:
         # Google AI / Gemini API (ai.google.dev); LangChain may wrap HTTP/GRPC text.

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -17,9 +17,12 @@ T = TypeVar("T", bound=BaseModel)
 class GeminiLLM(JudgeLLM):
     """Gemini implementation using LangChain.
 
-    Google GenAI Context Caching (``cached_content`` resource names) is not wired here;
+    Newer Gemini models may use the API's **implicit** prompt caching automatically
+    (shared-prefix requests); this client does not add special flags for that.
+
+    **Explicit** Context Caching (``cached_content`` resource names) is not wired here;
     it needs a separate cache create/update lifecycle. There is no Anthropic-style
-    ``cache_control`` on ``ChatGoogleGenerativeAI`` for one-flag prefix caching.
+    ``cache_control`` on ``ChatGoogleGenerativeAI``.
     """
 
     def _no_retry_substrings(self) -> tuple[str, ...]:

--- a/llm_clients/openai_llm.py
+++ b/llm_clients/openai_llm.py
@@ -15,7 +15,14 @@ T = TypeVar("T", bound=BaseModel)
 
 
 class OpenAILLM(JudgeLLM):
-    """OpenAI implementation using LangChain."""
+    """OpenAI implementation using LangChain.
+
+    Prompt caching is automatic for eligible models/prefixes; we pass
+    ``prompt_cache_key`` (per conversation) on each call so routing can improve
+    cache hits.
+    Since this is automatic, we do not require something like
+    Anthropic's ``cache_control``.
+    """
 
     def _no_retry_substrings(self) -> tuple[str, ...]:
         # https://platform.openai.com/docs/guides/error-codes
@@ -118,7 +125,10 @@ class OpenAILLM(JudgeLLM):
 
         async def _invoke() -> str:
             start_time = time.time()
-            response = await self.llm.ainvoke(messages)
+            response = await self.llm.ainvoke(
+                messages,
+                prompt_cache_key=self.conversation_id,
+            )
             end_time = time.time()
 
             self._set_response_metadata(
@@ -199,7 +209,10 @@ class OpenAILLM(JudgeLLM):
             structured_llm = self.llm.with_structured_output(response_model)
 
             start_time = time.time()
-            response = await structured_llm.ainvoke(messages)
+            response = await structured_llm.ainvoke(
+                messages,
+                prompt_cache_key=self.conversation_id,
+            )
             end_time = time.time()
 
             self._set_response_metadata(

--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -156,6 +156,80 @@ class TestClaudeLLM(TestJudgeLLMBase):
     @pytest.mark.asyncio
     @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
     @patch("llm_clients.claude_llm.ChatAnthropic")
+    async def test_generate_response_propagates_cache_usage_tokens(
+        self, mock_chat_anthropic, mock_response_factory, mock_system_message
+    ):
+        """Copy cache_creation_input_tokens and cache_read_input_tokens into usage."""
+        mock_response = mock_response_factory(
+            text="Cached context response",
+            response_id="msg_cache",
+            provider="claude",
+            metadata={
+                "model": "claude-sonnet-4-5-20250929",
+                "usage": {
+                    "input_tokens": 10,
+                    "output_tokens": 20,
+                    "cache_creation_input_tokens": 100,
+                    "cache_read_input_tokens": 200,
+                },
+                "stop_reason": "end_turn",
+            },
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.model = "claude-sonnet-4-5-20250929"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_anthropic.return_value = mock_llm
+
+        llm = ClaudeLLM(
+            name="TestClaude",
+            role=Role.PERSONA,
+            system_prompt="You are a helpful assistant.",
+        )
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        usage = llm.last_response_metadata["usage"]
+        assert usage["cache_creation_input_tokens"] == 100
+        assert usage["cache_read_input_tokens"] == 200
+        assert usage["total_tokens"] == 30
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
+    @patch("llm_clients.claude_llm.ChatAnthropic")
+    async def test_generate_response_omits_none_cache_usage_keys(
+        self, mock_chat_anthropic, mock_response_factory, mock_system_message
+    ):
+        """None cache token values are not copied into last_response_metadata usage."""
+        mock_response = mock_response_factory(
+            text="Response",
+            response_id="msg_cache_none",
+            provider="claude",
+            metadata={
+                "model": "claude-sonnet-4-5-20250929",
+                "usage": {
+                    "input_tokens": 5,
+                    "output_tokens": 5,
+                    "cache_creation_input_tokens": None,
+                    "cache_read_input_tokens": None,
+                },
+            },
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.model = "claude-sonnet-4-5-20250929"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_anthropic.return_value = mock_llm
+
+        llm = ClaudeLLM(name="TestClaude", role=Role.PERSONA)
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        usage = llm.last_response_metadata["usage"]
+        assert "cache_creation_input_tokens" not in usage
+        assert "cache_read_input_tokens" not in usage
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
+    @patch("llm_clients.claude_llm.ChatAnthropic")
     async def test_generate_response_without_system_prompt(
         self, mock_chat_anthropic, mock_response_factory, mock_system_message
     ):

--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -196,6 +196,40 @@ class TestClaudeLLM(TestJudgeLLMBase):
     @pytest.mark.asyncio
     @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
     @patch("llm_clients.claude_llm.ChatAnthropic")
+    async def test_caching_false_omits_cache_control_on_invoke(
+        self, mock_chat_anthropic, mock_response_factory, mock_system_message
+    ):
+        """When caching=False, ainvoke receives no cache_control kwarg."""
+        mock_response = mock_response_factory(
+            text="No cache",
+            response_id="msg_nocache",
+            provider="claude",
+            metadata={
+                "model": "claude-sonnet-4-5-20250929",
+                "usage": {"input_tokens": 1, "output_tokens": 2},
+                "stop_reason": "end_turn",
+            },
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.model = "claude-sonnet-4-5-20250929"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_anthropic.return_value = mock_llm
+
+        llm = ClaudeLLM(
+            name="TestClaude",
+            role=Role.PERSONA,
+            system_prompt="You are a helpful assistant.",
+            caching=False,
+        )
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        mock_llm.ainvoke.assert_called_once()
+        assert "cache_control" not in mock_llm.ainvoke.call_args.kwargs
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
+    @patch("llm_clients.claude_llm.ChatAnthropic")
     async def test_generate_response_omits_none_cache_usage_keys(
         self, mock_chat_anthropic, mock_response_factory, mock_system_message
     ):

--- a/tests/unit/llm_clients/test_openai_llm.py
+++ b/tests/unit/llm_clients/test_openai_llm.py
@@ -139,9 +139,13 @@ class TestOpenAILLM(TestJudgeLLMBase):
             role=Role.PERSONA,
             system_prompt="You are a helpful assistant.",
         )
+        expected_cache_key = llm.conversation_id
         response = await llm.generate_response(conversation_history=mock_system_message)
 
         assert response == "This is an OpenAI response"
+        assert (
+            mock_llm.ainvoke.call_args.kwargs["prompt_cache_key"] == expected_cache_key
+        )
 
         # Verify comprehensive metadata extraction
         metadata = assert_metadata_structure(
@@ -695,10 +699,15 @@ class TestOpenAILLM(TestJudgeLLMBase):
             llm = OpenAILLM(
                 name="TestOpenAI", role=Role.JUDGE, system_prompt="Test prompt"
             )
+            expected_cache_key = llm.conversation_id
             response = await llm.generate_structured_response(
                 "What is the answer?", TestResponse
             )
 
+            assert (
+                mock_structured_llm.ainvoke.call_args.kwargs["prompt_cache_key"]
+                == expected_cache_key
+            )
             assert isinstance(response, TestResponse)
             assert response.answer == "Yes"
             assert response.reasoning == "Because it's correct"


### PR DESCRIPTION
## Description
Anthropic's chat API has caching turned off by default.
With the growing chat history per turn, this PR ensures caching for claude.

## Result
Each claude model has a threshold before caching begins, but once it does, we can note it in a convo log's metadata:
```json
{
    "raw_metadata": {
        "id": "msg_01CUeyzM5CnzzSDLzZQZ7zTK",
        "model": "claude-haiku-4-5-20251001",
        "stop_reason": "end_turn",
        "stop_sequence": null, 
        "usage": {
            "cache_creation": {
                "ephemeral_1h_input_tokens": 0, 
                "ephemeral_5m_input_tokens": 64
            },
            "cache_creation_input_tokens": 64,
            "cache_read_input_tokens": 4579,
            "input_tokens": 3,
            "output_tokens": 9,
            "server_tool_use": null,
            "service_tier": "standard",
            "inference_geo": "not_available"
        }
    }, 
        "stop_details": null, 
        "model_name": "claude-haiku-4-5-20251001", 
        "model_provider": "anthropic"
}
```