### PR TITLE
look for p_ convo output

### DIFF
--- a/judge.py
+++ b/judge.py
@@ -15,7 +15,11 @@ from typing import Optional
 from judge import judge_conversations, judge_single_conversation
 from judge.llm_judge import LLMJudge
 from judge.rubric_config import ConversationData, RubricConfig, load_conversations
-from judge.utils import build_judge_task_log_path, parse_judge_models
+from judge.utils import (
+    build_judge_task_log_path,
+    default_adhoc_parent,
+    parse_judge_models,
+)
 from utils.conversation_layout import resolve_conversation_input
 from utils.naming import (
     build_single_conversation_run_folder_name,
@@ -97,7 +101,8 @@ def get_parser() -> argparse.ArgumentParser:
             "Batch: parent directory for a new j_*__* folder (default: "
             "<gen_run>/evaluations/ when -f points at a nested p_* run, else "
             "evaluations/). With --resume, must be the existing j_* run folder. "
-            "Single-file (-c): parent for single_<ts>__<stem>/ (default: output/adhoc)."
+            "Single-file (-c): parent for single_<ts>__<stem>/ "
+            "(default: output/adhoc; env VERA_ADHOC_PARENT overrides)."
         ),
     )
     parser.add_argument(
@@ -165,7 +170,7 @@ async def main(args) -> Optional[str]:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
         single_name = build_single_conversation_run_folder_name(stem, ts)
         if args.output is None:
-            parent = os.path.join("output", "adhoc")
+            parent = default_adhoc_parent()
         else:
             parent = args.output
         os.makedirs(parent, exist_ok=True)

--- a/judge/llm_judge.py
+++ b/judge/llm_judge.py
@@ -9,7 +9,7 @@ from judge.constants import BEST_PRACTICE, DAMAGING, NEUTRAL
 from judge.question_navigator import QuestionNavigator
 from judge.response_models import QuestionResponse
 from judge.rubric_config import ConversationData, RubricConfig
-from judge.utils import judge_evaluation_tsv_filename
+from judge.utils import default_adhoc_parent, judge_evaluation_tsv_filename
 from llm_clients import LLMFactory, Role
 from llm_clients.llm_interface import JudgeLLM
 
@@ -46,19 +46,19 @@ class LLMJudge:
             judge_model: Model to use for judging
             rubric_config: Pre-loaded rubric configuration data
             judge_model_extra_params: Extra parameters for the judge model
-            log_file: Path to log file (default under output/adhoc/judge_unscoped/)
+            log_file: Path to log file (default under <adhoc>/judge_unscoped/; see
+                default_adhoc_parent() / VERA_ADHOC_PARENT)
             verbose: Whether to print verbose output during initialization
         """
 
         # Setup logger: batch judging and `judge.py` pass an explicit path from
         # build_judge_task_log_path (scoped to the run). Omitted log_file is only
-        # for direct construction, tests, etc.—then we use output/adhoc/judge_unscoped/
-        # with a UUID stem so concurrent sessions do not overwrite.
+        # for direct construction, tests, etc.—then judge_unscoped/ under
+        # default_adhoc_parent(); UUID stem avoids concurrent overwrites.
         scoped = log_file is not None
         if not scoped:
             log_file = str(
-                Path("output")
-                / "adhoc"
+                Path(default_adhoc_parent())
                 / "judge_unscoped"
                 / f"judge_{uuid.uuid4().hex}.log"
             )

--- a/judge/utils.py
+++ b/judge/utils.py
@@ -243,3 +243,12 @@ def extract_persona_name_from_filename(filename: str) -> Optional[str]:
     except Exception as e:
         print(f"Error extracting persona name from filename {filename}: {e}")
         return None
+
+
+def default_adhoc_parent() -> str:
+    """
+    Parent directory for single-file judge runs and unscoped LLMJudge log dirs.
+
+    Set VERA_ADHOC_PARENT to override (tests use a temp directory).
+    """
+    return os.environ.get("VERA_ADHOC_PARENT") or os.path.join("output", "adhoc")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,22 +9,29 @@ from judge.rubric_config import RubricConfig
 from tests.mocks.mock_llm import MockLLM
 
 _judge_logs_temp: Path | None = None
+_adhoc_temp: Path | None = None
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    """Point judge file logs at a temp dir for this session (cleaned in finish)."""
-    global _judge_logs_temp
+    """Point judge file logs and adhoc outputs at temp dirs (cleaned in finish)."""
+    global _judge_logs_temp, _adhoc_temp
     _judge_logs_temp = Path(tempfile.mkdtemp(prefix="vera_judge_logs_"))
     os.environ["VERA_JUDGE_LOGS_ROOT"] = str(_judge_logs_temp)
+    _adhoc_temp = Path(tempfile.mkdtemp(prefix="vera_adhoc_"))
+    os.environ["VERA_ADHOC_PARENT"] = str(_adhoc_temp)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Remove temp judge logs; clear env so CLI uses ./judge_logs/."""
-    global _judge_logs_temp
+    """Remove temp dirs; clear env so CLI uses normal defaults."""
+    global _judge_logs_temp, _adhoc_temp
     os.environ.pop("VERA_JUDGE_LOGS_ROOT", None)
+    os.environ.pop("VERA_ADHOC_PARENT", None)
     if _judge_logs_temp is not None and _judge_logs_temp.exists():
         shutil.rmtree(_judge_logs_temp, ignore_errors=True)
     _judge_logs_temp = None
+    if _adhoc_temp is not None and _adhoc_temp.exists():
+        shutil.rmtree(_adhoc_temp, ignore_errors=True)
+    _adhoc_temp = None
 
 
 @pytest.fixture

--- a/tests/unit/judge/test_judge_cli.py
+++ b/tests/unit/judge/test_judge_cli.py
@@ -162,7 +162,9 @@ class TestJudgeMain:
             ja = judge_single.await_args[0]
             assert ja[0] == "judge_instance"
             assert ja[1] == "conversation_data"
-            assert str(ja[2]).startswith("output/adhoc/single_")
+            out_run = Path(ja[2])
+            assert out_run.name.startswith("single_")
+            assert out_run.name.endswith("__conv")
             assert result == ja[2]
 
     @pytest.mark.asyncio

--- a/tests/unit/utils/test_conversation_layout.py
+++ b/tests/unit/utils/test_conversation_layout.py
@@ -34,6 +34,26 @@ class TestResolveConversationInput:
         assert gen == str(run)
         assert base == run.name
 
+    def test_empty_nested_conversations_subdir_no_double_path(self, tmp_path):
+        """Empty .../conversations/ still resolves to itself and lifts p_* run id."""
+        run = tmp_path / "p_gpt_4o_mini__a_gpt_4o_mini__t6__r1__20260424_105639"
+        nested = run / "conversations"
+        nested.mkdir(parents=True)
+
+        td, gen, base = resolve_conversation_input(str(nested))
+        assert td == str(nested)
+        assert gen == str(run)
+        assert base == run.name
+
+    def test_empty_conversations_under_non_generation_parent(self, tmp_path):
+        nested = tmp_path / "adhoc" / "conversations"
+        nested.mkdir(parents=True)
+
+        td, gen, base = resolve_conversation_input(str(nested))
+        assert td == str(nested)
+        assert gen is None
+        assert base == "conversations"
+
     def test_conversations_under_non_generation_parent_is_legacy(self, tmp_path):
         """A non-p_* parent keeps legacy gen_run=None (basename conversations)."""
         nested = tmp_path / "my_batch" / "conversations"

--- a/tests/unit/utils/test_conversation_layout.py
+++ b/tests/unit/utils/test_conversation_layout.py
@@ -22,6 +22,29 @@ class TestResolveConversationInput:
         assert gen == str(run)
         assert base == run.name
 
+    def test_path_is_nested_conversations_subdir_lifts_gen_run(self, tmp_path):
+        """Transcripts under a nested conversations/ dir use the parent run basename."""
+        run = tmp_path / "p_gpt_4o_mini__a_gpt_4o_mini__t6__r1__20260424_105639"
+        nested = run / "conversations"
+        nested.mkdir(parents=True)
+        (nested / "a.txt").write_text("hi", encoding="utf-8")
+
+        td, gen, base = resolve_conversation_input(str(nested))
+        assert td == str(nested)
+        assert gen == str(run)
+        assert base == run.name
+
+    def test_conversations_under_non_generation_parent_is_legacy(self, tmp_path):
+        """A non-p_* parent keeps legacy gen_run=None (basename conversations)."""
+        nested = tmp_path / "my_batch" / "conversations"
+        nested.mkdir(parents=True)
+        (nested / "a.txt").write_text("hi", encoding="utf-8")
+
+        td, gen, base = resolve_conversation_input(str(nested))
+        assert td == str(nested)
+        assert gen is None
+        assert base == "conversations"
+
     def test_legacy_flat_root_txt(self, tmp_path):
         flat = tmp_path / "old_run"
         flat.mkdir()

--- a/utils/conversation_layout.py
+++ b/utils/conversation_layout.py
@@ -16,11 +16,13 @@ def resolve_conversation_input(folder: str) -> tuple[str, Optional[str], str]:
 
     - If ``folder/conversations/`` contains ``.txt`` files, ``folder`` is treated as
       a generation run root; transcripts are read from ``folder/conversations``.
-    - If ``folder`` is named ``conversations``, contains ``.txt`` files, and its
-      parent's basename passes ``is_generation_run_folder_basename`` (canonical
-      ``p_*__a_*__t*__r*__*`` layout from ``utils.naming``), treat ``folder`` as
-      that run's nested transcript directory (same as passing the parent). This
-      keeps judge run folder names and score metadata aligned with the run id.
+    - If ``folder`` is named ``conversations`` (with or without ``.txt`` files yet)
+      and its parent's basename passes ``is_generation_run_folder_basename``
+      (canonical ``p_*__a_*__t*__r*__*`` layout from ``utils.naming``), treat
+      ``folder`` as that run's nested transcript directory (same as passing the
+      parent). This keeps judge run folder names and score metadata aligned with
+      the run id and avoids resolving to a bogus ``.../conversations/conversations``
+      path before the first transcript is written.
     - Otherwise, if ``folder`` itself contains ``.txt`` files, use the legacy flat
       layout (``gen_run_root`` is None).
     - If ``folder/conversations/`` exists but has no ``.txt`` files yet, use that
@@ -50,6 +52,14 @@ def resolve_conversation_input(folder: str) -> tuple[str, Optional[str], str]:
                 and is_generation_run_folder_basename(parent_base)
             ):
                 return folder, parent, parent_base
+        return folder, None, basename
+    # Path already ends in .../conversations/ but no .txt yet (or only non-.txt files):
+    # do not fall through to folder/conversations (double "conversations").
+    if basename == "conversations" and os.path.isdir(folder):
+        parent = os.path.dirname(folder)
+        parent_base = os.path.basename(parent) if parent else ""
+        if parent and parent_base and is_generation_run_folder_basename(parent_base):
+            return folder, parent, parent_base
         return folder, None, basename
     if os.path.isdir(nested):
         return nested, folder, basename

--- a/utils/conversation_layout.py
+++ b/utils/conversation_layout.py
@@ -3,6 +3,8 @@
 import os
 from typing import Optional
 
+from .naming import is_generation_run_folder_basename
+
 
 def resolve_conversation_input(folder: str) -> tuple[str, Optional[str], str]:
     """
@@ -14,6 +16,11 @@ def resolve_conversation_input(folder: str) -> tuple[str, Optional[str], str]:
 
     - If ``folder/conversations/`` contains ``.txt`` files, ``folder`` is treated as
       a generation run root; transcripts are read from ``folder/conversations``.
+    - If ``folder`` is named ``conversations``, contains ``.txt`` files, and its
+      parent's basename passes ``is_generation_run_folder_basename`` (canonical
+      ``p_*__a_*__t*__r*__*`` layout from ``utils.naming``), treat ``folder`` as
+      that run's nested transcript directory (same as passing the parent). This
+      keeps judge run folder names and score metadata aligned with the run id.
     - Otherwise, if ``folder`` itself contains ``.txt`` files, use the legacy flat
       layout (``gen_run_root`` is None).
     - If ``folder/conversations/`` exists but has no ``.txt`` files yet, use that
@@ -34,6 +41,15 @@ def resolve_conversation_input(folder: str) -> tuple[str, Optional[str], str]:
     if dir_has_txt_files(nested):
         return nested, folder, basename
     if dir_has_txt_files(folder):
+        if basename == "conversations":
+            parent = os.path.dirname(folder)
+            parent_base = os.path.basename(parent)
+            if (
+                parent
+                and parent_base
+                and is_generation_run_folder_basename(parent_base)
+            ):
+                return folder, parent, parent_base
         return folder, None, basename
     if os.path.isdir(nested):
         return nested, folder, basename


### PR DESCRIPTION
## Description
With the new output defaults, conversations are now stored under p_.../conversations/*.txt instead of conversations/p_.../*.txt

When passing p_.../conversations as the input to judge, it creates a judge folder called j_...conversations instead of j_...p_... which caused "Unknown" User name and Agent name 💀 

This PR addresses looking one level up for the expected p_... dir name to preserve user and agent information