### PR TITLE
remove test outputs

### DIFF
--- a/judge.py
+++ b/judge.py
@@ -15,7 +15,11 @@ from typing import Optional
 from judge import judge_conversations, judge_single_conversation
 from judge.llm_judge import LLMJudge
 from judge.rubric_config import ConversationData, RubricConfig, load_conversations
-from judge.utils import build_judge_task_log_path, parse_judge_models
+from judge.utils import (
+    build_judge_task_log_path,
+    default_adhoc_parent,
+    parse_judge_models,
+)
 from utils.conversation_layout import resolve_conversation_input
 from utils.naming import (
     build_single_conversation_run_folder_name,
@@ -97,7 +101,8 @@ def get_parser() -> argparse.ArgumentParser:
             "Batch: parent directory for a new j_*__* folder (default: "
             "<gen_run>/evaluations/ when -f points at a nested p_* run, else "
             "evaluations/). With --resume, must be the existing j_* run folder. "
-            "Single-file (-c): parent for single_<ts>__<stem>/ (default: output/adhoc)."
+            "Single-file (-c): parent for single_<ts>__<stem>/ "
+            "(default: output/adhoc; env VERA_ADHOC_PARENT overrides)."
         ),
     )
     parser.add_argument(
@@ -165,7 +170,7 @@ async def main(args) -> Optional[str]:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S_%f")[:-3]
         single_name = build_single_conversation_run_folder_name(stem, ts)
         if args.output is None:
-            parent = os.path.join("output", "adhoc")
+            parent = default_adhoc_parent()
         else:
             parent = args.output
         os.makedirs(parent, exist_ok=True)

--- a/judge/llm_judge.py
+++ b/judge/llm_judge.py
@@ -9,7 +9,7 @@ from judge.constants import BEST_PRACTICE, DAMAGING, NEUTRAL
 from judge.question_navigator import QuestionNavigator
 from judge.response_models import QuestionResponse
 from judge.rubric_config import ConversationData, RubricConfig
-from judge.utils import judge_evaluation_tsv_filename
+from judge.utils import default_adhoc_parent, judge_evaluation_tsv_filename
 from llm_clients import LLMFactory, Role
 from llm_clients.llm_interface import JudgeLLM
 
@@ -46,19 +46,19 @@ class LLMJudge:
             judge_model: Model to use for judging
             rubric_config: Pre-loaded rubric configuration data
             judge_model_extra_params: Extra parameters for the judge model
-            log_file: Path to log file (default under output/adhoc/judge_unscoped/)
+            log_file: Path to log file (default under <adhoc>/judge_unscoped/; see
+                default_adhoc_parent() / VERA_ADHOC_PARENT)
             verbose: Whether to print verbose output during initialization
         """
 
         # Setup logger: batch judging and `judge.py` pass an explicit path from
         # build_judge_task_log_path (scoped to the run). Omitted log_file is only
-        # for direct construction, tests, etc.—then we use output/adhoc/judge_unscoped/
-        # with a UUID stem so concurrent sessions do not overwrite.
+        # for direct construction, tests, etc.—then judge_unscoped/ under
+        # default_adhoc_parent(); UUID stem avoids concurrent overwrites.
         scoped = log_file is not None
         if not scoped:
             log_file = str(
-                Path("output")
-                / "adhoc"
+                Path(default_adhoc_parent())
                 / "judge_unscoped"
                 / f"judge_{uuid.uuid4().hex}.log"
             )

--- a/judge/utils.py
+++ b/judge/utils.py
@@ -243,3 +243,12 @@ def extract_persona_name_from_filename(filename: str) -> Optional[str]:
     except Exception as e:
         print(f"Error extracting persona name from filename {filename}: {e}")
         return None
+
+
+def default_adhoc_parent() -> str:
+    """
+    Parent directory for single-file judge runs and unscoped LLMJudge log dirs.
+
+    Set VERA_ADHOC_PARENT to override (tests use a temp directory).
+    """
+    return os.environ.get("VERA_ADHOC_PARENT") or os.path.join("output", "adhoc")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,22 +9,29 @@ from judge.rubric_config import RubricConfig
 from tests.mocks.mock_llm import MockLLM
 
 _judge_logs_temp: Path | None = None
+_adhoc_temp: Path | None = None
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:
-    """Point judge file logs at a temp dir for this session (cleaned in finish)."""
-    global _judge_logs_temp
+    """Point judge file logs and adhoc outputs at temp dirs (cleaned in finish)."""
+    global _judge_logs_temp, _adhoc_temp
     _judge_logs_temp = Path(tempfile.mkdtemp(prefix="vera_judge_logs_"))
     os.environ["VERA_JUDGE_LOGS_ROOT"] = str(_judge_logs_temp)
+    _adhoc_temp = Path(tempfile.mkdtemp(prefix="vera_adhoc_"))
+    os.environ["VERA_ADHOC_PARENT"] = str(_adhoc_temp)
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
-    """Remove temp judge logs; clear env so CLI uses ./judge_logs/."""
-    global _judge_logs_temp
+    """Remove temp dirs; clear env so CLI uses normal defaults."""
+    global _judge_logs_temp, _adhoc_temp
     os.environ.pop("VERA_JUDGE_LOGS_ROOT", None)
+    os.environ.pop("VERA_ADHOC_PARENT", None)
     if _judge_logs_temp is not None and _judge_logs_temp.exists():
         shutil.rmtree(_judge_logs_temp, ignore_errors=True)
     _judge_logs_temp = None
+    if _adhoc_temp is not None and _adhoc_temp.exists():
+        shutil.rmtree(_adhoc_temp, ignore_errors=True)
+    _adhoc_temp = None
 
 
 @pytest.fixture

--- a/tests/unit/judge/test_judge_cli.py
+++ b/tests/unit/judge/test_judge_cli.py
@@ -162,7 +162,9 @@ class TestJudgeMain:
             ja = judge_single.await_args[0]
             assert ja[0] == "judge_instance"
             assert ja[1] == "conversation_data"
-            assert str(ja[2]).startswith("output/adhoc/single_")
+            out_run = Path(ja[2])
+            assert out_run.name.startswith("single_")
+            assert out_run.name.endswith("__conv")
             assert result == ja[2]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Description
When running tests, the output directory had leftover test assets

This PR ensures a clean setup/teardown

## Issue
closes https://github.com/SpringCare/VERA-MH/pull/152