### PR TITLE
support removing deprecated params for LLMs

### DIFF
--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -26,6 +26,10 @@ class ClaudeLLM(JudgeLLM):
     Prompt caching uses Anthropic's per-request ``cache_control`` (see ``caching`` and
     ``anthropic_cache_control`` constructor args).
     """
+
+    _UNSUPPORTED_MODEL_PARAMS: ClassVar[Dict[str, frozenset[str]]] = {
+        "opus-4-8": frozenset({"temperature"}),
+    }
 
     def _no_retry_substrings(self) -> tuple[str, ...]:
         # Anthropic API / Messages API (see https://docs.anthropic.com/en/api/errors)
@@ -77,6 +81,7 @@ class ClaudeLLM(JudgeLLM):
 
         # Override with any provided kwargs
         llm_params.update(kwargs)
+        llm_params = self._filter_supported_params(self.model_name, llm_params)
 
         # Print configuration before creating LLM
         print("Creating Claude LLM with parameters:")

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, ClassVar, Dict, List, Optional, Type, TypeVar
+from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.messages import HumanMessage, SystemMessage
@@ -27,9 +27,10 @@ class ClaudeLLM(JudgeLLM):
     ``anthropic_cache_control`` constructor args).
     """
 
-    _UNSUPPORTED_MODEL_PARAMS: ClassVar[Dict[str, frozenset[str]]] = {
-        "opus-4-8": frozenset({"temperature"}),
-    }
+    def _unsupported_model_params(self) -> Dict[str, frozenset[str]]:
+        return {
+            "opus-4-8": frozenset({"temperature"}),
+        }
 
     def _no_retry_substrings(self) -> tuple[str, ...]:
         # Anthropic API / Messages API (see https://docs.anthropic.com/en/api/errors)

--- a/llm_clients/llm_interface.py
+++ b/llm_clients/llm_interface.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from enum import Enum
-from typing import Any, ClassVar, Dict, List, Optional, Protocol, Type, TypeVar
+from typing import Any, Dict, List, Optional, Protocol, Type, TypeVar
 
 from pydantic import BaseModel
 
@@ -69,10 +69,6 @@ class LLMInterface(ABC):
       the LLM to generate the first turn. Defaults to DEFAULT_START_PROMPT.
     """
 
-    # Model name substring -> runtime params the API rejects for that model.
-    # Provider subclasses override with provider-specific constraints.
-    _UNSUPPORTED_MODEL_PARAMS: ClassVar[Dict[str, frozenset[str]]] = {}
-
     def __init__(
         self,
         name: str,
@@ -119,24 +115,29 @@ class LLMInterface(ABC):
         """
         return str(uuid.uuid4())
 
-    @classmethod
-    def _model_supports_param(cls, model_name: str, param_name: str) -> bool:
+    def _unsupported_model_params(self) -> Dict[str, frozenset[str]]:
+        """Model name substring -> runtime params the API rejects for that model.
+
+        Override on concrete LLMs with provider-specific constraints.
+        """
+        return {}
+
+    def _model_supports_param(self, model_name: str, param_name: str) -> bool:
         """Return False when ``param_name`` must not be sent for ``model_name``."""
         model_lower = model_name.lower()
         param_lower = param_name.lower()
-        for model_marker, unsupported in cls._UNSUPPORTED_MODEL_PARAMS.items():
+        for model_marker, unsupported in self._unsupported_model_params().items():
             if model_marker in model_lower:
                 if param_lower in {p.lower() for p in unsupported}:
                     return False
         return True
 
-    @classmethod
     def _filter_supported_params(
-        cls, model_name: str, params: Dict[str, Any]
+        self, model_name: str, params: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Drop runtime params that ``model_name`` does not accept."""
         return {
-            k: v for k, v in params.items() if cls._model_supports_param(model_name, k)
+            k: v for k, v in params.items() if self._model_supports_param(model_name, k)
         }
 
     def _update_conversation_id_from_metadata(self) -> None:

--- a/llm_clients/llm_interface.py
+++ b/llm_clients/llm_interface.py
@@ -6,7 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional, Protocol, Type, TypeVar
+from typing import Any, ClassVar, Dict, List, Optional, Protocol, Type, TypeVar
 
 from pydantic import BaseModel
 
@@ -69,6 +69,10 @@ class LLMInterface(ABC):
       the LLM to generate the first turn. Defaults to DEFAULT_START_PROMPT.
     """
 
+    # Model name substring -> runtime params the API rejects for that model.
+    # Provider subclasses override with provider-specific constraints.
+    _UNSUPPORTED_MODEL_PARAMS: ClassVar[Dict[str, frozenset[str]]] = {}
+
     def __init__(
         self,
         name: str,
@@ -114,6 +118,26 @@ class LLMInterface(ABC):
         Subclasses may override to use a different id format.
         """
         return str(uuid.uuid4())
+
+    @classmethod
+    def _model_supports_param(cls, model_name: str, param_name: str) -> bool:
+        """Return False when ``param_name`` must not be sent for ``model_name``."""
+        model_lower = model_name.lower()
+        param_lower = param_name.lower()
+        for model_marker, unsupported in cls._UNSUPPORTED_MODEL_PARAMS.items():
+            if model_marker in model_lower:
+                if param_lower in {p.lower() for p in unsupported}:
+                    return False
+        return True
+
+    @classmethod
+    def _filter_supported_params(
+        cls, model_name: str, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Drop runtime params that ``model_name`` does not accept."""
+        return {
+            k: v for k, v in params.items() if cls._model_supports_param(model_name, k)
+        }
 
     def _update_conversation_id_from_metadata(self) -> None:
         """If the API returned a conversation_id in response metadata, use it.

--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -106,6 +106,35 @@ class TestClaudeLLM(TestJudgeLLMBase):
             assert call_kwargs["max_tokens"] == 500
             assert call_kwargs["top_p"] == 0.9
 
+    def test_init_strips_temperature_for_opus_4_8(self, default_llm_kwargs):
+        """Opus 4.8 rejects temperature; it must not be passed to ChatAnthropic."""
+        with patch("llm_clients.claude_llm.ChatAnthropic") as mock_chat_anthropic:
+            mock_llm = MagicMock()
+            mock_llm.model = "claude-opus-4-8"
+            mock_chat_anthropic.return_value = mock_llm
+
+            ClaudeLLM(
+                name="TestClaude",
+                role=Role.JUDGE,
+                model_name="claude-opus-4-8",
+                **default_llm_kwargs,
+            )
+
+            call_kwargs = mock_chat_anthropic.call_args[1]
+            assert "temperature" not in call_kwargs
+            assert call_kwargs["max_tokens"] == 500
+
+    def test_model_supports_param_unsupported_for_opus_4_8(self):
+        assert not ClaudeLLM._model_supports_param("claude-opus-4-8", "temperature")
+
+    def test_model_supports_param_case_insensitive(self):
+        assert not ClaudeLLM._model_supports_param("Claude-Opus-4-8", "Temperature")
+
+    def test_filter_supported_params_strips_temperature_for_opus_4_8(self):
+        params = {"temperature": 0, "max_tokens": 500, "top_p": 0.9}
+        filtered = ClaudeLLM._filter_supported_params("claude-opus-4-8", params)
+        assert filtered == {"max_tokens": 500, "top_p": 0.9}
+
     @pytest.mark.asyncio
     @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
     @patch("llm_clients.claude_llm.ChatAnthropic")

--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -124,15 +124,38 @@ class TestClaudeLLM(TestJudgeLLMBase):
             assert "temperature" not in call_kwargs
             assert call_kwargs["max_tokens"] == 500
 
-    def test_model_supports_param_unsupported_for_opus_4_8(self):
-        assert not ClaudeLLM._model_supports_param("claude-opus-4-8", "temperature")
+    def test_model_supports_param_unsupported_for_opus_4_8(self, default_llm_kwargs):
+        with patch("llm_clients.claude_llm.ChatAnthropic"):
+            llm = ClaudeLLM(
+                name="TestClaude",
+                role=Role.JUDGE,
+                model_name="claude-opus-4-8",
+                **default_llm_kwargs,
+            )
+        assert not llm._model_supports_param("claude-opus-4-8", "temperature")
 
-    def test_model_supports_param_case_insensitive(self):
-        assert not ClaudeLLM._model_supports_param("Claude-Opus-4-8", "Temperature")
+    def test_model_supports_param_case_insensitive(self, default_llm_kwargs):
+        with patch("llm_clients.claude_llm.ChatAnthropic"):
+            llm = ClaudeLLM(
+                name="TestClaude",
+                role=Role.JUDGE,
+                model_name="claude-opus-4-8",
+                **default_llm_kwargs,
+            )
+        assert not llm._model_supports_param("Claude-Opus-4-8", "Temperature")
 
-    def test_filter_supported_params_strips_temperature_for_opus_4_8(self):
+    def test_filter_supported_params_strips_temperature_for_opus_4_8(
+        self, default_llm_kwargs
+    ):
+        with patch("llm_clients.claude_llm.ChatAnthropic"):
+            llm = ClaudeLLM(
+                name="TestClaude",
+                role=Role.JUDGE,
+                model_name="claude-opus-4-8",
+                **default_llm_kwargs,
+            )
         params = {"temperature": 0, "max_tokens": 500, "top_p": 0.9}
-        filtered = ClaudeLLM._filter_supported_params("claude-opus-4-8", params)
+        filtered = llm._filter_supported_params("claude-opus-4-8", params)
         assert filtered == {"max_tokens": 500, "top_p": 0.9}
 
     @pytest.mark.asyncio

--- a/tests/unit/llm_clients/test_llm_interface.py
+++ b/tests/unit/llm_clients/test_llm_interface.py
@@ -565,16 +565,20 @@ class TestModelParamSupport:
     """Tests for model-specific runtime parameter support on the base class."""
 
     def test_model_supports_param_default(self):
-        assert LLMInterface._model_supports_param("any-model", "temperature")
+        llm = ConcreteLLM(name="TestLLM", role=Role.PROVIDER)
+        assert llm._model_supports_param("any-model", "temperature")
 
-    def test_base_class_has_empty_unsupported_params_map(self):
-        assert LLMInterface._UNSUPPORTED_MODEL_PARAMS == {}
-        assert LLMInterface._model_supports_param("any-model", "temperature")
+    def test_base_class_returns_empty_unsupported_params_map(self):
+        llm = ConcreteLLM(name="TestLLM", role=Role.PROVIDER)
+        assert llm._unsupported_model_params() == {}
+        assert llm._model_supports_param("any-model", "temperature")
 
     def test_filter_supported_params_passthrough(self):
+        llm = ConcreteLLM(name="TestLLM", role=Role.PROVIDER)
         params = {"temperature": 0, "max_tokens": 500, "top_p": 0.9}
-        filtered = LLMInterface._filter_supported_params("any-model", params)
+        filtered = llm._filter_supported_params("any-model", params)
         assert filtered == params
 
     def test_subclass_can_access_model_supports_param(self):
-        assert ConcreteLLM._model_supports_param("any-model", "temperature")
+        llm = ConcreteLLM(name="TestLLM", role=Role.PROVIDER)
+        assert llm._model_supports_param("any-model", "temperature")

--- a/tests/unit/llm_clients/test_llm_interface.py
+++ b/tests/unit/llm_clients/test_llm_interface.py
@@ -558,3 +558,23 @@ class TestLLMInterfaceHooks:
         metadata = h.last_response_metadata
         assert metadata["attempt"] == 4
         assert metadata["will_retry"] is False
+
+
+@pytest.mark.unit
+class TestModelParamSupport:
+    """Tests for model-specific runtime parameter support on the base class."""
+
+    def test_model_supports_param_default(self):
+        assert LLMInterface._model_supports_param("any-model", "temperature")
+
+    def test_base_class_has_empty_unsupported_params_map(self):
+        assert LLMInterface._UNSUPPORTED_MODEL_PARAMS == {}
+        assert LLMInterface._model_supports_param("any-model", "temperature")
+
+    def test_filter_supported_params_passthrough(self):
+        params = {"temperature": 0, "max_tokens": 500, "top_p": 0.9}
+        filtered = LLMInterface._filter_supported_params("any-model", params)
+        assert filtered == params
+
+    def test_subclass_can_access_model_supports_param(self):
+        assert ConcreteLLM._model_supports_param("any-model", "temperature")


### PR DESCRIPTION
## Description
Opus 4.8 was released and [deprecated params](https://platform.claude.com/docs/en/about-claude/model-deprecations#api-parameter-deprecations) that were set by default by judge init.

This PR filters deprecated params & adds temperature filter for claude opus 4.8