### PR TITLE
Improve convo & judge metadata logging

### DIFF
--- a/generate_conversations/conversation_simulator.py
+++ b/generate_conversations/conversation_simulator.py
@@ -19,6 +19,7 @@ class ConversationSimulator:
         self.persona = persona
         self.agent = agent
         self.conversation_history: List[ConversationTurn] = []
+        self.last_active_speaker: Optional[LLMInterface] = None
 
         # Define termination signals that indicate persona wants to end the conversation
         self.termination_signal = "<END OF CONVERSATION>"
@@ -69,6 +70,7 @@ class ConversationSimulator:
             List of conversation turns with speaker and message
         """
         self.conversation_history = []
+        self.last_active_speaker = None
         max_turns = ensure_provider_has_last_turn(max_turns, persona_speaks_first)
 
         if persona_speaks_first:
@@ -93,6 +95,7 @@ class ConversationSimulator:
                 f"[SIM] Turn {turn + 1}/{max_turns}: "
                 f"{current_speaker.name} ({current_speaker.role.value}) speaking"
             )
+            self.last_active_speaker = current_speaker
             # start or continue the conversation
             if turn == 0:
                 response = await current_speaker.start_conversation()

--- a/generate_conversations/runner.py
+++ b/generate_conversations/runner.py
@@ -17,6 +17,7 @@ from utils.logging_utils import (
     log_conversation_end,
     log_conversation_start,
     log_conversation_turn,
+    log_llm_failure_metadata,
     setup_conversation_logger,
 )
 from utils.naming import (
@@ -515,6 +516,12 @@ class ConversationRunner:
                             persona_name,
                             run_number,
                             str(e),
+                        )
+                        log_llm_failure_metadata(
+                            session_logger,
+                            simulator.last_active_speaker,
+                            context=f"{persona_name} run {run_number}",
+                            error=e,
                         )
                     cleanup_logger(session_logger)
                     sessions.append(

--- a/judge/llm_judge.py
+++ b/judge/llm_judge.py
@@ -9,7 +9,12 @@ from judge.constants import BEST_PRACTICE, DAMAGING, NEUTRAL
 from judge.question_navigator import QuestionNavigator
 from judge.response_models import QuestionResponse
 from judge.rubric_config import ConversationData, RubricConfig
-from judge.utils import default_adhoc_parent, judge_evaluation_tsv_filename
+from judge.utils import (
+    default_adhoc_parent,
+    judge_evaluation_tsv_filename,
+    log_llm_failure_metadata,
+    log_llm_response_metadata,
+)
 from llm_clients import LLMFactory, Role
 from llm_clients.llm_interface import JudgeLLM, LLMGenerationFailed
 
@@ -562,17 +567,12 @@ class LLMJudge:
         self, question_id: str, exc: LLMGenerationFailed
     ) -> None:
         """Log structured-output failure details to the per-conversation judge log."""
-        self.logger.error(f"STRUCTURED OUTPUT FAILED for question {question_id}: {exc}")
-        evaluator = self.evaluator
-        if evaluator is None:
-            return
-        metadata = getattr(evaluator, "last_response_metadata", None) or {}
-        debug = metadata.get("structured_output_debug")
-        if debug:
-            self.logger.error(f"structured_output_debug: {debug}")
-        for key in ("error", "attempt", "max_attempts", "retryable", "will_retry"):
-            if key in metadata:
-                self.logger.error(f"  {key}: {metadata[key]}")
+        log_llm_failure_metadata(
+            self.logger,
+            self.evaluator,
+            context=f"question {question_id}",
+            error=exc,
+        )
 
     async def _ask_single_question(
         self, question_id: str, question_data: Dict[str, Any], verbose: bool
@@ -622,6 +622,11 @@ class LLMJudge:
             raise
 
         self.logger.info(f"STRUCTURED RESPONSE:\n{structured_response}")
+        log_llm_response_metadata(
+            self.logger,
+            self.evaluator,
+            context=f"question {question_id}",
+        )
         if verbose:
             print(f"  Answer: {structured_response.answer}")
             print(f"  Reasoning: {structured_response.reasoning[:100]}...")

--- a/judge/runner.py
+++ b/judge/runner.py
@@ -4,7 +4,6 @@ Contains the main logic extracted from main_judge.py to reduce code duplication.
 """
 
 import asyncio
-import json
 import os
 from asyncio import Queue
 from datetime import datetime
@@ -12,8 +11,6 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pandas as pd
-
-from llm_clients.llm_interface import LLMGenerationFailed
 
 from .llm_judge import LLMJudge
 from .rubric_config import ConversationData, RubricConfig
@@ -26,22 +23,6 @@ from .utils import (
 
 # In case this needs to be synced in the meta prompt for the judge
 EVALUATION_SEPARATOR = ":"
-
-
-def _print_llm_failure_metadata(
-    judge: LLMJudge,
-    conversation_filename: str,
-    judge_model: str,
-) -> None:
-    """Print last LLM response metadata when a judge evaluation fails."""
-    evaluator = getattr(judge, "evaluator", None)
-    metadata = getattr(evaluator, "last_response_metadata", None) if evaluator else None
-    if not metadata:
-        return
-    print(
-        f"  LLM metadata for {conversation_filename} ({judge_model}): "
-        f"{json.dumps(metadata, indent=2, default=str)}"
-    )
 
 
 def _parse_evaluation_to_dict(evaluation: Dict[str, Any]) -> Dict[str, Any]:
@@ -105,17 +86,13 @@ async def _evaluate_single_conversation_with_judge(
         log_file=log_file,
     )
 
-    try:
-        evaluation = await judge.evaluate_conversation_question_flow(
-            conversation,
-            output_folder=output_folder,
-            auto_save=True,
-            verbose=False,
-            judge_instance=judge_instance,
-        )
-    except LLMGenerationFailed:
-        _print_llm_failure_metadata(judge, conversation_filename, judge_model)
-        raise
+    evaluation = await judge.evaluate_conversation_question_flow(
+        conversation,
+        output_folder=output_folder,
+        auto_save=True,
+        verbose=False,
+        judge_instance=judge_instance,
+    )
 
     try:
         evaluation_dict = _parse_evaluation_to_dict(evaluation)

--- a/judge/utils.py
+++ b/judge/utils.py
@@ -8,6 +8,18 @@ from typing import Dict, List, Optional, Tuple
 
 import pandas as pd
 
+from utils.logging_utils import (
+    extract_last_response_metadata,
+    log_llm_failure_metadata,
+    log_llm_response_metadata,
+)
+
+__all__ = [
+    "extract_last_response_metadata",
+    "log_llm_failure_metadata",
+    "log_llm_response_metadata",
+]
+
 
 def parse_judge_models(model_arg):
     """Parse judge model specifications from command line argument into a dictionary."""

--- a/llm_clients/azure_llm.py
+++ b/llm_clients/azure_llm.py
@@ -12,7 +12,12 @@ from utils.conversation_utils import build_langchain_messages
 from utils.debug import debug_print
 
 from .config import Config
-from .llm_interface import JudgeLLM, LLMGenerationFailed
+from .llm_interface import (
+    JudgeLLM,
+    LLMGenerationFailed,
+    ensure_pydantic_response,
+    extract_structured_invoke_result,
+)
 
 # Define type variable for Pydantic models
 T = TypeVar("T", bound=BaseModel)
@@ -148,6 +153,39 @@ class AzureLLM(JudgeLLM):
         self.max_tokens = getattr(self.llm, "max_tokens", None)
         self.top_p = getattr(self.llm, "top_p", None)
 
+    def _enrich_azure_message_metadata(self, response: Any) -> None:
+        """Merge token usage and response fields from a LangChain AIMessage."""
+        if response is None:
+            return
+
+        response_id = getattr(response, "id", None)
+        if response_id is not None:
+            self._last_response_metadata["response_id"] = response_id
+
+        model = (
+            getattr(response.response_metadata, "model", self.model_name)
+            if hasattr(response, "response_metadata")
+            else self.model_name
+        )
+        if model is not None:
+            self._last_response_metadata["model"] = model
+
+        if hasattr(response, "response_metadata") and response.response_metadata:
+            metadata = response.response_metadata
+
+            if "token_usage" in metadata:
+                usage = metadata["token_usage"]
+                self._last_response_metadata["usage"] = {
+                    "input_tokens": usage.get("input_tokens", 0),
+                    "output_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                }
+
+            self._last_response_metadata["finish_reason"] = metadata.get(
+                "finish_reason"
+            )
+            self._last_response_metadata["raw_metadata"] = dict(metadata)
+
     async def start_conversation(self) -> str:
         """Produce the first response:
         - static first_message if set, or
@@ -243,23 +281,7 @@ class AzureLLM(JudgeLLM):
                 finish_reason=None,
                 response=response,
             )
-
-            if hasattr(response, "response_metadata") and response.response_metadata:
-                metadata = response.response_metadata
-
-                if "token_usage" in metadata:
-                    usage = metadata["token_usage"]
-                    self._last_response_metadata["usage"] = {
-                        "input_tokens": usage.get("input_tokens", 0),
-                        "output_tokens": usage.get("output_tokens", 0),
-                        "total_tokens": usage.get("total_tokens", 0),
-                    }
-
-                self._last_response_metadata["finish_reason"] = metadata.get(
-                    "finish_reason"
-                )
-
-                self._last_response_metadata["raw_metadata"] = dict(metadata)
+            self._enrich_azure_message_metadata(response)
 
             return response.text
 
@@ -285,11 +307,14 @@ class AzureLLM(JudgeLLM):
         messages.append(HumanMessage(content=message))
 
         async def _invoke() -> T:
-            structured_llm = self.llm.with_structured_output(response_model)
+            structured_llm = self.llm.with_structured_output(
+                response_model,
+                include_raw=True,
+            )
 
             try:
                 start_time = time.time()
-                response = await structured_llm.ainvoke(messages)
+                invoke_result = await structured_llm.ainvoke(messages)
                 end_time = time.time()
             except Exception as e:
                 error_msg = str(e)
@@ -300,18 +325,22 @@ class AzureLLM(JudgeLLM):
                     ) from e
                 raise
 
+            parsed, raw, _ = extract_structured_invoke_result(invoke_result)
+            response = ensure_pydantic_response(parsed, response_model)
+
             self._set_response_metadata(
                 "azure",
                 response_time_seconds=round(end_time - start_time, 3),
                 structured_output=True,
             )
+            self._enrich_azure_message_metadata(raw)
 
-            if not isinstance(response, response_model):
+            if response is None:
                 raise ValueError(
                     f"Response is not an instance of {response_model.__name__}"
                 )
 
-            return response  # type: ignore[return-value]
+            return response
 
         return await self._run_with_retry(_invoke, provider="azure")
 

--- a/llm_clients/azure_llm.py
+++ b/llm_clients/azure_llm.py
@@ -162,13 +162,7 @@ class AzureLLM(JudgeLLM):
         if response_id is not None:
             self._last_response_metadata["response_id"] = response_id
 
-        model = (
-            getattr(response.response_metadata, "model", self.model_name)
-            if hasattr(response, "response_metadata")
-            else self.model_name
-        )
-        if model is not None:
-            self._last_response_metadata["model"] = model
+        self._last_response_metadata["model"] = self._extract_response_model(response)
 
         if hasattr(response, "response_metadata") and response.response_metadata:
             metadata = response.response_metadata
@@ -268,11 +262,7 @@ class AzureLLM(JudgeLLM):
                     raise LLMGenerationFailed(helpful_msg) from e
                 raise
 
-            model = (
-                getattr(response.response_metadata, "model", self.model_name)
-                if hasattr(response, "response_metadata")
-                else self.model_name
-            )
+            model = self._extract_response_model(response)
             self._set_response_metadata(
                 "azure",
                 response_id=getattr(response, "id", None),

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -113,13 +113,7 @@ class ClaudeLLM(JudgeLLM):
         if response_id is not None:
             self._last_response_metadata["response_id"] = response_id
 
-        model = (
-            getattr(response.response_metadata, "model", self.model_name)
-            if hasattr(response, "response_metadata")
-            else self.model_name
-        )
-        if model is not None:
-            self._last_response_metadata["model"] = model
+        self._last_response_metadata["model"] = self._extract_response_model(response)
 
         if hasattr(response, "response_metadata") and response.response_metadata:
             metadata = response.response_metadata
@@ -185,11 +179,7 @@ class ClaudeLLM(JudgeLLM):
             response = await self.llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()
 
-            model = (
-                getattr(response.response_metadata, "model", self.model_name)
-                if hasattr(response, "response_metadata")
-                else self.model_name
-            )
+            model = self._extract_response_model(response)
             self._set_response_metadata(
                 "claude",
                 response_id=getattr(response, "id", None),

--- a/llm_clients/claude_llm.py
+++ b/llm_clients/claude_llm.py
@@ -9,7 +9,12 @@ from utils.conversation_utils import build_langchain_messages
 from utils.debug import debug_print
 
 from .config import Config
-from .llm_interface import JudgeLLM, Role
+from .llm_interface import (
+    JudgeLLM,
+    Role,
+    ensure_pydantic_response,
+    extract_structured_invoke_result,
+)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -99,6 +104,42 @@ class ClaudeLLM(JudgeLLM):
         self.temperature = getattr(self.llm, "temperature", None)
         self.max_tokens = getattr(self.llm, "max_tokens", None)
 
+    def _enrich_claude_message_metadata(self, response: Any) -> None:
+        """Merge token usage and response fields from a LangChain AIMessage."""
+        if response is None:
+            return
+
+        response_id = getattr(response, "id", None)
+        if response_id is not None:
+            self._last_response_metadata["response_id"] = response_id
+
+        model = (
+            getattr(response.response_metadata, "model", self.model_name)
+            if hasattr(response, "response_metadata")
+            else self.model_name
+        )
+        if model is not None:
+            self._last_response_metadata["model"] = model
+
+        if hasattr(response, "response_metadata") and response.response_metadata:
+            metadata = response.response_metadata
+            if "usage" in metadata:
+                usage = metadata["usage"]
+                self._last_response_metadata["usage"] = {
+                    "input_tokens": usage.get("input_tokens", 0),
+                    "output_tokens": usage.get("output_tokens", 0),
+                    "total_tokens": usage.get("input_tokens", 0)
+                    + usage.get("output_tokens", 0),
+                }
+                for ck in (
+                    "cache_creation_input_tokens",
+                    "cache_read_input_tokens",
+                ):
+                    if usage.get(ck) is not None:
+                        self._last_response_metadata["usage"][ck] = usage[ck]
+            self._last_response_metadata["stop_reason"] = metadata.get("stop_reason")
+            self._last_response_metadata["raw_metadata"] = dict(metadata)
+
     async def start_conversation(self) -> str:
         """Produce the first response:
         - static first_message if set, or
@@ -157,27 +198,7 @@ class ClaudeLLM(JudgeLLM):
                 stop_reason=None,
                 response=response,
             )
-
-            if hasattr(response, "response_metadata") and response.response_metadata:
-                metadata = response.response_metadata
-                if "usage" in metadata:
-                    usage = metadata["usage"]
-                    self._last_response_metadata["usage"] = {
-                        "input_tokens": usage.get("input_tokens", 0),
-                        "output_tokens": usage.get("output_tokens", 0),
-                        "total_tokens": usage.get("input_tokens", 0)
-                        + usage.get("output_tokens", 0),
-                    }
-                    for ck in (
-                        "cache_creation_input_tokens",
-                        "cache_read_input_tokens",
-                    ):
-                        if usage.get(ck) is not None:
-                            self._last_response_metadata["usage"][ck] = usage[ck]
-                self._last_response_metadata["stop_reason"] = metadata.get(
-                    "stop_reason"
-                )
-                self._last_response_metadata["raw_metadata"] = dict(metadata)
+            self._enrich_claude_message_metadata(response)
 
             return response.text
 
@@ -203,27 +224,34 @@ class ClaudeLLM(JudgeLLM):
         messages.append(HumanMessage(content=message))
 
         async def _invoke() -> T:
-            structured_llm = self.llm.with_structured_output(response_model)
+            structured_llm = self.llm.with_structured_output(
+                response_model,
+                include_raw=True,
+            )
 
             start_time = time.time()
             invoke_kw: Dict[str, Any] = {}
             if self._anthropic_cache_control is not None:
                 invoke_kw["cache_control"] = self._anthropic_cache_control
-            response = await structured_llm.ainvoke(messages, **invoke_kw)
+            invoke_result = await structured_llm.ainvoke(messages, **invoke_kw)
             end_time = time.time()
+
+            parsed, raw, _ = extract_structured_invoke_result(invoke_result)
+            response = ensure_pydantic_response(parsed, response_model)
 
             self._set_response_metadata(
                 "claude",
                 response_time_seconds=round(end_time - start_time, 3),
                 structured_output=True,
             )
+            self._enrich_claude_message_metadata(raw)
 
-            if not isinstance(response, response_model):
+            if response is None:
                 raise ValueError(
                     f"Response is not an instance of {response_model.__name__}"
                 )
 
-            return response  # type: ignore[return-value]
+            return response
 
         return await self._run_with_retry(_invoke, provider="claude")
 

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -147,13 +147,7 @@ class GeminiLLM(JudgeLLM):
         if response_id is not None:
             self._last_response_metadata["response_id"] = response_id
 
-        model = (
-            getattr(response.response_metadata, "model_name", self.model_name)
-            if hasattr(response, "response_metadata")
-            else self.model_name
-        )
-        if model is not None:
-            self._last_response_metadata["model"] = model
+        self._last_response_metadata["model"] = self._extract_response_model(response)
 
         if hasattr(response, "response_metadata") and response.response_metadata:
             metadata = response.response_metadata
@@ -221,11 +215,7 @@ class GeminiLLM(JudgeLLM):
             response = await self.llm.ainvoke(messages)
             end_time = time.time()
 
-            model = (
-                getattr(response.response_metadata, "model_name", self.model_name)
-                if hasattr(response, "response_metadata")
-                else self.model_name
-            )
+            model = self._extract_response_model(response)
             self._set_response_metadata(
                 "gemini",
                 response_id=getattr(response, "id", None),

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -4,13 +4,18 @@ from typing import Any, Dict, List, Optional, Type, TypeVar
 
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_google_genai import ChatGoogleGenerativeAI
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from utils.conversation_utils import build_langchain_messages
 from utils.debug import debug_print
 
 from .config import Config
-from .llm_interface import JudgeLLM, Role
+from .llm_interface import (
+    JudgeLLM,
+    Role,
+    ensure_pydantic_response,
+    extract_structured_invoke_result,
+)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -54,33 +59,6 @@ def _serialize_raw_message(raw: Any) -> Dict[str, Any]:
             payload["additional_kwargs"] = dict(raw.additional_kwargs)
         return payload
     return {"type": type(raw).__name__, "repr": _truncate_for_log(raw)}
-
-
-def _extract_include_raw_result(
-    invoke_result: Any,
-) -> tuple[Any, Any, Any]:
-    """Unpack LangChain include_raw=True structured output payloads."""
-    if isinstance(invoke_result, dict) and "parsed" in invoke_result:
-        return (
-            invoke_result.get("parsed"),
-            invoke_result.get("raw"),
-            invoke_result.get("parsing_error"),
-        )
-    return invoke_result, None, None
-
-
-def _coerce_structured_response(response: Any, response_model: Type[T]) -> Optional[T]:
-    """Normalize structured LLM output to a Pydantic model instance."""
-    if response is None:
-        return None
-    if isinstance(response, response_model):
-        return response
-    if isinstance(response, dict):
-        try:
-            return response_model.model_validate(response)
-        except ValidationError:
-            return None
-    return None
 
 
 class GeminiLLM(JudgeLLM):
@@ -156,6 +134,46 @@ class GeminiLLM(JudgeLLM):
         self.temperature = getattr(self.llm, "temperature", None)
         self.max_tokens = getattr(self.llm, "max_tokens", None)
 
+    def _enrich_gemini_message_metadata(self, response: Any) -> None:
+        """Merge token usage and response fields from a LangChain AIMessage."""
+        if response is None:
+            return
+
+        response_id = getattr(response, "id", None)
+        if response_id is not None:
+            self._last_response_metadata["response_id"] = response_id
+
+        model = (
+            getattr(response.response_metadata, "model_name", self.model_name)
+            if hasattr(response, "response_metadata")
+            else self.model_name
+        )
+        if model is not None:
+            self._last_response_metadata["model"] = model
+
+        if hasattr(response, "response_metadata") and response.response_metadata:
+            metadata = response.response_metadata
+
+            if "usage_metadata" in metadata:
+                usage = metadata["usage_metadata"]
+                self._last_response_metadata["usage"] = {
+                    "prompt_token_count": usage.get("prompt_token_count", 0),
+                    "candidates_token_count": usage.get("candidates_token_count", 0),
+                    "total_token_count": usage.get("total_token_count", 0),
+                }
+            elif "token_usage" in metadata:
+                usage = metadata["token_usage"]
+                self._last_response_metadata["usage"] = {
+                    "prompt_tokens": usage.get("prompt_tokens", 0),
+                    "completion_tokens": usage.get("completion_tokens", 0),
+                    "total_tokens": usage.get("total_tokens", 0),
+                }
+
+            self._last_response_metadata["finish_reason"] = metadata.get(
+                "finish_reason"
+            )
+            self._last_response_metadata["raw_metadata"] = dict(metadata)
+
     async def start_conversation(self) -> str:
         """Produce the first response:
         - static first_message if set, or
@@ -212,32 +230,7 @@ class GeminiLLM(JudgeLLM):
                 finish_reason=None,
                 response=response,
             )
-
-            if hasattr(response, "response_metadata") and response.response_metadata:
-                metadata = response.response_metadata
-
-                if "usage_metadata" in metadata:
-                    usage = metadata["usage_metadata"]
-                    self._last_response_metadata["usage"] = {
-                        "prompt_token_count": usage.get("prompt_token_count", 0),
-                        "candidates_token_count": usage.get(
-                            "candidates_token_count", 0
-                        ),
-                        "total_token_count": usage.get("total_token_count", 0),
-                    }
-                elif "token_usage" in metadata:
-                    usage = metadata["token_usage"]
-                    self._last_response_metadata["usage"] = {
-                        "prompt_tokens": usage.get("prompt_tokens", 0),
-                        "completion_tokens": usage.get("completion_tokens", 0),
-                        "total_tokens": usage.get("total_tokens", 0),
-                    }
-
-                self._last_response_metadata["finish_reason"] = metadata.get(
-                    "finish_reason"
-                )
-
-                self._last_response_metadata["raw_metadata"] = dict(metadata)
+            self._enrich_gemini_message_metadata(response)
 
             return response.text
 
@@ -301,8 +294,8 @@ class GeminiLLM(JudgeLLM):
             invoke_result = await structured_llm.ainvoke(messages)
             end_time = time.time()
 
-            parsed, raw, parsing_error = _extract_include_raw_result(invoke_result)
-            coerced = _coerce_structured_response(parsed, response_model)
+            parsed, raw, parsing_error = extract_structured_invoke_result(invoke_result)
+            response = ensure_pydantic_response(parsed, response_model)
 
             self._set_response_metadata(
                 "gemini",
@@ -310,14 +303,15 @@ class GeminiLLM(JudgeLLM):
                 structured_output=True,
                 structured_output_method="json_schema",
             )
+            self._enrich_gemini_message_metadata(raw)
 
-            if coerced is not None:
+            if response is not None:
                 failure_debug.clear()
                 debug_print(
                     f"[DEBUG {self.name}] Structured {response_model.__name__}: "
-                    f"{coerced!r}"
+                    f"{response!r}"
                 )
-                return coerced
+                return response
 
             failure_debug.clear()
             failure_debug.update(

--- a/llm_clients/gemini_llm.py
+++ b/llm_clients/gemini_llm.py
@@ -43,8 +43,12 @@ def _raw_message_content_for_log(raw: Any) -> str:
 def _serialize_raw_message(raw: Any) -> Dict[str, Any]:
     """Serialize an AIMessage (or similar) for failure diagnostics.
 
-    Omits message content; use ``raw_content`` on the failure debug dict for a
-    truncated body preview so logs stay bounded when the dict is printed whole.
+    Returns the structural ``raw`` sub-dict (type, tool_calls, response_metadata,
+    etc.) used inside :meth:`_build_structured_output_failure_debug`. It
+    deliberately omits ``AIMessage.content`` here so the body is not duplicated
+    inside nested metadata. The caller adds a separate top-level ``raw_content``
+    key with a truncated text preview — one bounded copy of the response text
+    when the whole failure debug dict is logged.
     """
     if raw is None:
         return {}

--- a/llm_clients/llm_interface.py
+++ b/llm_clients/llm_interface.py
@@ -17,7 +17,35 @@ R = TypeVar("R")
 def extract_structured_invoke_result(
     invoke_result: Any,
 ) -> tuple[Any, Any, Any]:
-    """Unpack LangChain ``include_raw=True`` structured output payloads."""
+    """Unpack LangChain ``include_raw=True`` structured output payloads.
+
+    With ``include_raw=True``, ``structured_llm.ainvoke(...)`` returns a dict
+    instead of a bare Pydantic model. We split it into ``(parsed, raw, error)``
+    so callers can use the model *and* read token usage from the raw AIMessage.
+
+    Toy example::
+
+        # LangChain returns something like:
+        invoke_result = {
+            "parsed": QuestionResponse(answer="Yes", reasoning="..."),
+            "raw": AIMessage(  # has response_metadata / usage_metadata
+                content='{"answer": "Yes", "reasoning": "..."}',
+                response_metadata={"token_usage": {...}},
+            ),
+            "parsing_error": None,
+        }
+
+        parsed, raw, parsing_error = extract_structured_invoke_result(invoke_result)
+        # parsed -> QuestionResponse(...)
+        # raw -> AIMessage(...)  (use for usage logging)
+        # parsing_error -> None
+
+    Without ``include_raw``, LangChain returns only the parsed model::
+
+        invoke_result = QuestionResponse(answer="Yes", reasoning="...")
+        parsed, raw, parsing_error = extract_structured_invoke_result(invoke_result)
+        # parsed -> QuestionResponse(...), raw -> None, parsing_error -> None
+    """
     if isinstance(invoke_result, dict) and "parsed" in invoke_result:
         return (
             invoke_result.get("parsed"),

--- a/llm_clients/llm_interface.py
+++ b/llm_clients/llm_interface.py
@@ -8,10 +8,37 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Protocol, Type, TypeVar
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 T = TypeVar("T", bound=BaseModel)
 R = TypeVar("R")
+
+
+def extract_structured_invoke_result(
+    invoke_result: Any,
+) -> tuple[Any, Any, Any]:
+    """Unpack LangChain ``include_raw=True`` structured output payloads."""
+    if isinstance(invoke_result, dict) and "parsed" in invoke_result:
+        return (
+            invoke_result.get("parsed"),
+            invoke_result.get("raw"),
+            invoke_result.get("parsing_error"),
+        )
+    return invoke_result, None, None
+
+
+def ensure_pydantic_response(response: Any, response_model: Type[T]) -> Optional[T]:
+    """Return a Pydantic model instance from structured LLM output, or None."""
+    if response is None:
+        return None
+    if isinstance(response, response_model):
+        return response
+    if isinstance(response, dict):
+        try:
+            return response_model.model_validate(response)
+        except ValidationError:
+            return None
+    return None
 
 
 class RetryOnErrorCallback(Protocol):

--- a/llm_clients/llm_interface.py
+++ b/llm_clients/llm_interface.py
@@ -280,6 +280,23 @@ class LLMInterface(ABC):
             f"LLM call failed after {max_attempts} attempts: {last_exception}"
         ) from last_exception
 
+    def _extract_response_model(self, response: Any) -> Optional[str]:
+        """Extract model identifier from a LangChain AIMessage response."""
+        metadata_obj = getattr(response, "response_metadata", None)
+        model = None
+        if metadata_obj is not None:
+            for key in ("model", "model_name"):
+                if isinstance(metadata_obj, dict):
+                    value = metadata_obj.get(key)
+                else:
+                    value = getattr(metadata_obj, key, None)
+                if isinstance(value, str) and value:
+                    model = value
+                    break
+        if model is None:
+            model = getattr(self, "model_name", None)
+        return model
+
     def _set_response_metadata(self, provider: str, **extra: Any) -> None:
         """Set last_response_metadata with common fields; pass extra keys as kwargs.
 

--- a/llm_clients/openai_llm.py
+++ b/llm_clients/openai_llm.py
@@ -99,11 +99,10 @@ class OpenAILLM(JudgeLLM):
                 response.additional_kwargs
             )
 
+        self._last_response_metadata["model"] = self._extract_response_model(response)
+
         if hasattr(response, "response_metadata") and response.response_metadata:
             metadata = response.response_metadata
-
-            if "model_name" in metadata:
-                self._last_response_metadata["model"] = metadata["model_name"]
 
             if "token_usage" in metadata:
                 token_usage = metadata["token_usage"]

--- a/llm_clients/openai_llm.py
+++ b/llm_clients/openai_llm.py
@@ -9,7 +9,12 @@ from utils.conversation_utils import build_langchain_messages
 from utils.debug import debug_print
 
 from .config import Config
-from .llm_interface import JudgeLLM, Role
+from .llm_interface import (
+    JudgeLLM,
+    Role,
+    ensure_pydantic_response,
+    extract_structured_invoke_result,
+)
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -80,6 +85,55 @@ class OpenAILLM(JudgeLLM):
 
         self.llm = ChatOpenAI(**llm_params)
 
+    def _enrich_openai_message_metadata(self, response: Any) -> None:
+        """Merge token usage and response fields from a LangChain AIMessage."""
+        if response is None:
+            return
+
+        response_id = getattr(response, "id", None)
+        if response_id is not None:
+            self._last_response_metadata["response_id"] = response_id
+
+        if hasattr(response, "additional_kwargs") and response.additional_kwargs:
+            self._last_response_metadata["additional_kwargs"] = dict(
+                response.additional_kwargs
+            )
+
+        if hasattr(response, "response_metadata") and response.response_metadata:
+            metadata = response.response_metadata
+
+            if "model_name" in metadata:
+                self._last_response_metadata["model"] = metadata["model_name"]
+
+            if "token_usage" in metadata:
+                token_usage = metadata["token_usage"]
+                self._last_response_metadata["usage"] = {
+                    "prompt_tokens": token_usage.get("prompt_tokens", 0),
+                    "completion_tokens": token_usage.get("completion_tokens", 0),
+                    "total_tokens": token_usage.get("total_tokens", 0),
+                }
+
+            self._last_response_metadata["finish_reason"] = metadata.get(
+                "finish_reason"
+            )
+            self._last_response_metadata["system_fingerprint"] = metadata.get(
+                "system_fingerprint"
+            )
+            self._last_response_metadata["logprobs"] = metadata.get("logprobs")
+            self._last_response_metadata["raw_response_metadata"] = dict(metadata)
+
+        if hasattr(response, "usage_metadata") and response.usage_metadata:
+            usage_meta = response.usage_metadata
+            self._last_response_metadata.setdefault("usage", {})
+            self._last_response_metadata["usage"].update(
+                {
+                    "input_tokens": usage_meta.get("input_tokens", 0),
+                    "output_tokens": usage_meta.get("output_tokens", 0),
+                    "total_tokens": usage_meta.get("total_tokens", 0),
+                }
+            )
+            self._last_response_metadata["raw_usage_metadata"] = dict(usage_meta)
+
     async def start_conversation(self) -> str:
         """Produce the first response:
         - static first_message if set, or
@@ -141,46 +195,7 @@ class OpenAILLM(JudgeLLM):
                 logprobs=None,
                 response=response,
             )
-
-            if hasattr(response, "additional_kwargs") and response.additional_kwargs:
-                self._last_response_metadata["additional_kwargs"] = dict(
-                    response.additional_kwargs
-                )
-
-            if hasattr(response, "response_metadata") and response.response_metadata:
-                metadata = response.response_metadata
-
-                if "model_name" in metadata:
-                    self._last_response_metadata["model"] = metadata["model_name"]
-
-                if "token_usage" in metadata:
-                    token_usage = metadata["token_usage"]
-                    self._last_response_metadata["usage"] = {
-                        "prompt_tokens": token_usage.get("prompt_tokens", 0),
-                        "completion_tokens": token_usage.get("completion_tokens", 0),
-                        "total_tokens": token_usage.get("total_tokens", 0),
-                    }
-
-                self._last_response_metadata["finish_reason"] = metadata.get(
-                    "finish_reason"
-                )
-                self._last_response_metadata["system_fingerprint"] = metadata.get(
-                    "system_fingerprint"
-                )
-                self._last_response_metadata["logprobs"] = metadata.get("logprobs")
-
-                self._last_response_metadata["raw_response_metadata"] = dict(metadata)
-
-            if hasattr(response, "usage_metadata") and response.usage_metadata:
-                usage_meta = response.usage_metadata
-                self._last_response_metadata["usage"].update(
-                    {
-                        "input_tokens": usage_meta.get("input_tokens", 0),
-                        "output_tokens": usage_meta.get("output_tokens", 0),
-                        "total_tokens": usage_meta.get("total_tokens", 0),
-                    }
-                )
-                self._last_response_metadata["raw_usage_metadata"] = dict(usage_meta)
+            self._enrich_openai_message_metadata(response)
 
             return response.text
 
@@ -206,27 +221,34 @@ class OpenAILLM(JudgeLLM):
         messages.append(HumanMessage(content=message))
 
         async def _invoke() -> T:
-            structured_llm = self.llm.with_structured_output(response_model)
+            structured_llm = self.llm.with_structured_output(
+                response_model,
+                include_raw=True,
+            )
 
             start_time = time.time()
-            response = await structured_llm.ainvoke(
+            invoke_result = await structured_llm.ainvoke(
                 messages,
                 prompt_cache_key=self.conversation_id,
             )
             end_time = time.time()
+
+            parsed, raw, _ = extract_structured_invoke_result(invoke_result)
+            response = ensure_pydantic_response(parsed, response_model)
 
             self._set_response_metadata(
                 "openai",
                 response_time_seconds=round(end_time - start_time, 3),
                 structured_output=True,
             )
+            self._enrich_openai_message_metadata(raw)
 
-            if not isinstance(response, response_model):
+            if response is None:
                 raise ValueError(
                     f"Response is not an instance of {response_model.__name__}"
                 )
 
-            return response  # type: ignore[return-value]
+            return response
 
         return await self._run_with_retry(_invoke, provider="openai")
 

--- a/tests/unit/llm_clients/test_azure_llm.py
+++ b/tests/unit/llm_clients/test_azure_llm.py
@@ -403,6 +403,26 @@ class TestAzureLLM(TestJudgeLLMBase):
         assert metadata["finish_reason"] is None
 
     @pytest.mark.asyncio
+    async def test_model_name_update_from_dict_metadata(
+        self, mock_azure_config, mock_azure_model, mock_system_message
+    ):
+        """Test that model name is updated from dict response metadata."""
+        mock_response = MagicMock()
+        mock_response.text = "Test"
+        mock_response.id = "chatcmpl-model"
+        mock_response.response_metadata = {"model": "gpt-4o-deployment"}
+
+        mock_llm = MagicMock()
+        mock_llm.model_name = "gpt-5.2"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_azure_model.return_value = mock_llm
+
+        llm = AzureLLM(name="TestAzure", role=Role.PERSONA, model_name="gpt-5.2")
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        assert llm.last_response_metadata["model"] == "gpt-4o-deployment"
+
+    @pytest.mark.asyncio
     async def test_generate_response_api_error(
         self, mock_azure_config, mock_azure_model, mock_system_message
     ):

--- a/tests/unit/llm_clients/test_base_llm.py
+++ b/tests/unit/llm_clients/test_base_llm.py
@@ -41,6 +41,10 @@ from .test_helpers import (
     assert_metadata_copy_behavior,
     assert_metadata_structure,
     assert_response_timing,
+    assert_structured_output_include_raw,
+    assert_structured_usage_values,
+    mock_raw_metadata_for_structured_usage,
+    structured_include_raw_invoke_result,
 )
 
 
@@ -376,6 +380,57 @@ class TestJudgeLLMBase(TestLLMBase):
                 "Structured output failed",
                 mock_ainvoke=mock_structured_llm.ainvoke,
             )
+
+    @pytest.mark.asyncio
+    async def test_generate_structured_response_captures_usage_from_raw(
+        self, mock_response_factory
+    ):
+        """Structured output must capture token usage from the raw AIMessage."""
+        with self.get_mock_patches():  # pyright: ignore[reportGeneralTypeIssues]
+
+            class TestResponse(BaseModel):
+                answer: str = Field(description="The answer")
+                reasoning: str = Field(description="The reasoning")
+
+            provider = self.get_provider_name()
+            test_response = TestResponse(answer="Yes", reasoning="Because")
+            raw_message = mock_response_factory(
+                text='{"answer": "Yes", "reasoning": "Because"}',
+                response_id=f"{provider}-structured-usage",
+                provider=provider,
+                metadata=mock_raw_metadata_for_structured_usage(provider),
+            )
+
+            mock_structured_llm = MagicMock()
+            mock_structured_llm.ainvoke = AsyncMock(
+                return_value=structured_include_raw_invoke_result(
+                    test_response, raw_message
+                )
+            )
+            mock_llm_client = MagicMock()
+            mock_llm_client.with_structured_output = MagicMock(
+                return_value=mock_structured_llm
+            )
+
+            llm = self.create_llm(role=Role.JUDGE, name="TestLLM")
+            llm.llm = mock_llm_client  # pyright: ignore[reportAttributeAccessIssue]
+
+            await llm.generate_structured_response("Evaluate", TestResponse)
+
+            assert_structured_output_include_raw(
+                mock_llm_client.with_structured_output, TestResponse
+            )
+
+            metadata = assert_metadata_structure(
+                llm,
+                expected_provider=provider,
+                expected_role=Role.JUDGE,
+                require_response_id=True,
+                require_usage=True,
+            )
+            assert metadata["structured_output"] is True
+            assert metadata["response_id"] == f"{provider}-structured-usage"
+            assert_structured_usage_values(metadata, provider)
 
     @pytest.mark.asyncio
     async def test_structured_response_invalid_type_raises_error(self):

--- a/tests/unit/llm_clients/test_claude_llm.py
+++ b/tests/unit/llm_clients/test_claude_llm.py
@@ -345,6 +345,33 @@ class TestClaudeLLM(TestJudgeLLMBase):
     @pytest.mark.asyncio
     @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
     @patch("llm_clients.claude_llm.ChatAnthropic")
+    async def test_model_name_update_from_metadata(
+        self, mock_chat_anthropic, mock_response_factory, mock_system_message
+    ):
+        """Test that model name is updated from dict response metadata."""
+        mock_response = mock_response_factory(
+            text="Test",
+            response_id="msg-model",
+            provider="claude",
+            metadata={"model": "claude-3-opus-20240229"},
+        )
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_anthropic.return_value = mock_llm
+
+        llm = ClaudeLLM(
+            name="TestClaude",
+            role=Role.PERSONA,
+            model_name="claude-sonnet-4-5-20250929",
+        )
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        assert llm.last_response_metadata["model"] == "claude-3-opus-20240229"
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.claude_llm.Config.ANTHROPIC_API_KEY", "test-key")
+    @patch("llm_clients.claude_llm.ChatAnthropic")
     async def test_generate_response_api_error(
         self, mock_chat_anthropic, mock_llm_factory, mock_system_message
     ):

--- a/tests/unit/llm_clients/test_gemini_llm.py
+++ b/tests/unit/llm_clients/test_gemini_llm.py
@@ -284,6 +284,31 @@ class TestGeminiLLM(TestJudgeLLMBase):
     @pytest.mark.asyncio
     @patch("llm_clients.gemini_llm.Config.GOOGLE_API_KEY", "test-key")
     @patch("llm_clients.gemini_llm.ChatGoogleGenerativeAI")
+    async def test_model_name_update_from_dict_metadata(
+        self, mock_chat_gemini, mock_system_message
+    ):
+        """Test that model name is updated from dict response metadata."""
+        mock_response = MagicMock()
+        mock_response.text = "Test"
+        mock_response.id = "gemini-model"
+        mock_response.response_metadata = {"model_name": "gemini-2.0-flash"}
+
+        mock_llm = MagicMock()
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        mock_chat_gemini.return_value = mock_llm
+
+        llm = GeminiLLM(
+            name="TestGemini",
+            role=Role.PERSONA,
+            model_name="gemini-1.5-pro",
+        )
+        await llm.generate_response(conversation_history=mock_system_message)
+
+        assert llm.last_response_metadata["model"] == "gemini-2.0-flash"
+
+    @pytest.mark.asyncio
+    @patch("llm_clients.gemini_llm.Config.GOOGLE_API_KEY", "test-key")
+    @patch("llm_clients.gemini_llm.ChatGoogleGenerativeAI")
     async def test_generate_response_api_error(
         self, mock_chat_gemini, mock_llm_factory, mock_system_message
     ):

--- a/tests/unit/llm_clients/test_helpers.py
+++ b/tests/unit/llm_clients/test_helpers.py
@@ -245,6 +245,112 @@ def assert_llm_generation_failed(
 
 
 # ============================================================================
+# Structured output test helpers
+# ============================================================================
+
+STRUCTURED_USAGE_INPUT = 500
+STRUCTURED_USAGE_OUTPUT = 42
+STRUCTURED_USAGE_TOTAL = 542
+
+
+def structured_include_raw_invoke_result(
+    parsed: Any,
+    raw: Any,
+    parsing_error: Any = None,
+) -> dict[str, Any]:
+    """LangChain ``include_raw=True`` payload for structured output mocks."""
+    return {
+        "parsed": parsed,
+        "raw": raw,
+        "parsing_error": parsing_error,
+    }
+
+
+def mock_raw_metadata_for_structured_usage(provider: str) -> Dict[str, Any]:
+    """Provider-specific usage metadata for mock raw AIMessages."""
+    if provider == "claude":
+        return {
+            "model": "claude-sonnet-4-5-20250929",
+            "usage": {
+                "input_tokens": STRUCTURED_USAGE_INPUT,
+                "output_tokens": STRUCTURED_USAGE_OUTPUT,
+            },
+            "stop_reason": "end_turn",
+        }
+    if provider == "openai":
+        return {
+            "model_name": "gpt-5.4-mini-2026-03-17",
+            "token_usage": {
+                "prompt_tokens": STRUCTURED_USAGE_INPUT,
+                "completion_tokens": STRUCTURED_USAGE_OUTPUT,
+                "total_tokens": STRUCTURED_USAGE_TOTAL,
+            },
+            "finish_reason": "stop",
+            "usage_metadata": {
+                "input_tokens": STRUCTURED_USAGE_INPUT,
+                "output_tokens": STRUCTURED_USAGE_OUTPUT,
+                "total_tokens": STRUCTURED_USAGE_TOTAL,
+            },
+        }
+    if provider == "azure":
+        return {
+            "token_usage": {
+                "input_tokens": STRUCTURED_USAGE_INPUT,
+                "output_tokens": STRUCTURED_USAGE_OUTPUT,
+                "total_tokens": STRUCTURED_USAGE_TOTAL,
+            },
+            "finish_reason": "stop",
+        }
+    if provider == "gemini":
+        return {
+            "model_name": "gemini-1.5-pro",
+            "usage_metadata": {
+                "prompt_token_count": STRUCTURED_USAGE_INPUT,
+                "candidates_token_count": STRUCTURED_USAGE_OUTPUT,
+                "total_token_count": STRUCTURED_USAGE_TOTAL,
+            },
+        }
+    raise ValueError(f"Unsupported provider: {provider}")
+
+
+def assert_structured_output_include_raw(
+    mock_with_structured_output: Any,
+    response_model: type,
+) -> None:
+    """Assert structured output was requested with include_raw=True."""
+    mock_with_structured_output.assert_called_once()
+    args, kwargs = mock_with_structured_output.call_args
+    assert args[0] is response_model
+    assert kwargs.get("include_raw") is True
+
+
+def assert_structured_usage_values(metadata: Dict[str, Any], provider: str) -> None:
+    """Assert provider-specific token usage was captured from the raw message."""
+    usage = metadata["usage"]
+    assert isinstance(usage, dict)
+    assert len(usage) > 0
+
+    if provider == "claude":
+        assert usage["input_tokens"] == STRUCTURED_USAGE_INPUT
+        assert usage["output_tokens"] == STRUCTURED_USAGE_OUTPUT
+        assert usage["total_tokens"] == STRUCTURED_USAGE_TOTAL
+    elif provider == "openai":
+        assert usage["input_tokens"] == STRUCTURED_USAGE_INPUT
+        assert usage["output_tokens"] == STRUCTURED_USAGE_OUTPUT
+        assert usage["total_tokens"] == STRUCTURED_USAGE_TOTAL
+    elif provider == "azure":
+        assert usage["input_tokens"] == STRUCTURED_USAGE_INPUT
+        assert usage["output_tokens"] == STRUCTURED_USAGE_OUTPUT
+        assert usage["total_tokens"] == STRUCTURED_USAGE_TOTAL
+    elif provider == "gemini":
+        assert usage["prompt_token_count"] == STRUCTURED_USAGE_INPUT
+        assert usage["candidates_token_count"] == STRUCTURED_USAGE_OUTPUT
+        assert usage["total_token_count"] == STRUCTURED_USAGE_TOTAL
+    else:
+        raise ValueError(f"Unsupported provider: {provider}")
+
+
+# ============================================================================
 # Mock Verification
 # ============================================================================
 

--- a/tests/unit/utils/test_logging_utils.py
+++ b/tests/unit/utils/test_logging_utils.py
@@ -7,12 +7,16 @@ import pytest
 
 from llm_clients import Role
 from tests.mocks.mock_llm import MockLLM
+from utils.debug import set_debug
 from utils.logging_utils import (
     cleanup_logger,
+    extract_last_response_metadata,
     log_conversation_end,
     log_conversation_start,
     log_conversation_turn,
     log_error,
+    log_llm_failure_metadata,
+    log_llm_response_metadata,
     setup_conversation_logger,
 )
 
@@ -545,6 +549,118 @@ class TestLogError:
         assert "ERROR: Value error occurred" in content
         assert "Exception: Invalid value provided" in content
         assert "Exception Type: ValueError" in content
+
+
+@pytest.mark.unit
+class TestLlmMetadataLogging:
+    """Test suite for LLM metadata logging helpers."""
+
+    @pytest.fixture(autouse=True)
+    def reset_debug(self):
+        set_debug(False)
+        yield
+        set_debug(False)
+
+    def test_extract_last_response_metadata_from_llm(self):
+        llm = MockLLM()
+        llm.last_response_metadata = {
+            "response_id": "resp-1",
+            "usage": {"input_tokens": 10, "output_tokens": 5},
+        }
+
+        metadata = extract_last_response_metadata(llm)
+
+        assert metadata["response_id"] == "resp-1"
+        assert metadata["usage"]["input_tokens"] == 10
+
+    def test_extract_last_response_metadata_from_wrapper(self):
+        llm = MockLLM()
+        llm.last_response_metadata = {"response_id": "inner"}
+
+        class Wrapper:
+            evaluator = llm
+
+        metadata = extract_last_response_metadata(Wrapper())
+
+        assert metadata["response_id"] == "inner"
+
+    def test_extract_last_response_metadata_none_returns_empty(self):
+        assert extract_last_response_metadata(None) == {}
+
+    def test_log_llm_response_metadata_writes_to_file(self, tmp_path):
+        logger = setup_conversation_logger(
+            "success_metadata",
+            log_dir=str(tmp_path / "logging" / "metadata_001"),
+        )
+        llm = MockLLM()
+        llm.last_response_metadata = {
+            "response_id": "resp-abc",
+            "usage": {"input_tokens": 100, "output_tokens": 20},
+        }
+
+        log_llm_response_metadata(logger, llm, context="question 1")
+
+        content = (
+            tmp_path / "logging" / "metadata_001" / "success_metadata.log"
+        ).read_text()
+        assert "response_id: resp-abc" in content
+        assert "logging: {'response_id': 'resp-abc'" in content
+        assert "'usage': {'input_tokens': 100, 'output_tokens': 20}" in content
+
+    def test_log_llm_failure_metadata_writes_to_file(self, tmp_path):
+        logger = setup_conversation_logger(
+            "failure_metadata",
+            log_dir=str(tmp_path / "logging" / "metadata_002"),
+        )
+        llm = MockLLM()
+        llm.last_response_metadata = {
+            "response_id": "resp-fail",
+            "usage": {"input_tokens": 50, "output_tokens": 0},
+            "structured_output_debug": {"raw_content": "{"},
+        }
+
+        log_llm_failure_metadata(
+            logger,
+            llm,
+            context="question 3",
+            error="LLM error (non-retryable): parse failed",
+        )
+
+        content = (
+            tmp_path / "logging" / "metadata_002" / "failure_metadata.log"
+        ).read_text()
+        assert "LLM GENERATION FAILED | context=question 3" in content
+        assert "LLM failure metadata:" in content
+        assert "resp-fail" in content
+        assert "structured_output_debug" in content
+
+    def test_log_llm_failure_metadata_debug_prints(self, tmp_path, capsys):
+        logger = setup_conversation_logger(
+            "failure_debug",
+            log_dir=str(tmp_path / "logging" / "metadata_003"),
+        )
+        llm = MockLLM()
+        llm.last_response_metadata = {"response_id": "resp-debug"}
+
+        set_debug(True)
+        log_llm_failure_metadata(logger, llm, context="turn 2", error="failed")
+
+        captured = capsys.readouterr()
+        assert "LLM metadata for turn 2" in captured.out
+        assert "resp-debug" in captured.out
+
+    def test_log_llm_response_metadata_no_print_without_debug(self, tmp_path, capsys):
+        logger = setup_conversation_logger(
+            "success_no_debug",
+            log_dir=str(tmp_path / "logging" / "metadata_004"),
+        )
+        llm = MockLLM()
+        llm.last_response_metadata = {"response_id": "resp-quiet"}
+
+        log_llm_response_metadata(logger, llm, context="question 5")
+
+        captured = capsys.readouterr()
+        assert captured.out == ""
 
 
 @pytest.mark.unit

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -131,8 +131,10 @@ def extract_last_response_metadata(llm: Any) -> dict[str, Any]:
     """Read last_response_metadata from an LLMInterface or wrapper with .evaluator."""
     if llm is None:
         return {}
+    # if LLMJudge passed as llm, get its self.evaluator else use llm
     evaluator = getattr(llm, "evaluator", None)
     target = evaluator if evaluator is not None else llm
+    # both conversation and judges store responses in last_response_metadata
     metadata = getattr(target, "last_response_metadata", None)
     return metadata or {}
 

--- a/utils/logging_utils.py
+++ b/utils/logging_utils.py
@@ -1,10 +1,13 @@
 """Utilities for conversation logging."""
 
+import json
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from llm_clients import LLMInterface
+
+from .debug import debug_print, is_debug
 
 
 def setup_conversation_logger(
@@ -122,6 +125,55 @@ def log_conversation_end(
     if total_time:
         logger.info(f"Duration: {total_time:.2f} seconds")
     logger.info("=" * 60)
+
+
+def extract_last_response_metadata(llm: Any) -> dict[str, Any]:
+    """Read last_response_metadata from an LLMInterface or wrapper with .evaluator."""
+    if llm is None:
+        return {}
+    evaluator = getattr(llm, "evaluator", None)
+    target = evaluator if evaluator is not None else llm
+    metadata = getattr(target, "last_response_metadata", None)
+    return metadata or {}
+
+
+def log_llm_response_metadata(
+    logger: logging.Logger,
+    llm: Any,
+    *,
+    context: str = "",
+) -> None:
+    """Log per-call metadata (token usage, response_id) after a successful LLM call."""
+    metadata = extract_last_response_metadata(llm)
+    logger.info(f"response_id: {metadata.get('response_id')}")
+    logger.info(f"logging: {metadata}")
+    if is_debug() and metadata:
+        label = f" for {context}" if context else ""
+        debug_print(
+            f"  LLM metadata{label}: {json.dumps(metadata, indent=2, default=str)}"
+        )
+
+
+def log_llm_failure_metadata(
+    logger: logging.Logger,
+    llm: Any,
+    *,
+    context: str,
+    error: str | Exception,
+) -> None:
+    """Log full failure metadata to file; debug_print when debug is enabled."""
+    logger.error("LLM GENERATION FAILED | context=%s error=%s", context, str(error))
+    metadata = extract_last_response_metadata(llm)
+    if metadata:
+        logger.error(
+            "LLM failure metadata: %s",
+            json.dumps(metadata, indent=2, default=str),
+        )
+    if is_debug() and metadata:
+        debug_print(
+            f"  LLM metadata for {context}: "
+            f"{json.dumps(metadata, indent=2, default=str)}"
+        )
 
 
 def log_error(


### PR DESCRIPTION
## Description
This PR started as an answer to comments in #157 but then as I live tested, turned into much more.

### Logging parity (judge + generate scripts)
- Added shared helpers in `utils/logging_utils.py`: `extract_last_response_metadata`, `log_llm_response_metadata`, `log_llm_failure_metadata`
- Re-exported from `judge/utils.py`
- **Judge:** per-question success metadata (`response_id`, `usage`) in judge logs; failures logged via shared helper (not stdout)
- **Generate:** on `LLMGenerationFailed`, logs full failure metadata to session log; tracks `last_active_speaker` in simulator
- **Debug:** metadata dumps print only with `--debug`; operational skip/progress messages unchanged
- Removed dead `_print_llm_failure_metadata` from `judge/runner.py` (logging happens in `llm_judge` while handlers are open)
- Pipeline / `judge.py` support for judge `--debug`

### Structured output + token usage (all judge providers)
- All JudgeLLM clients use `include_raw=True` and enrich metadata from the raw `AIMessage`
- Shared helpers: `extract_structured_invoke_result`, `ensure_pydantic_response` (renamed from `coerce_structured_response`)
- Per-provider `_enrich_*_message_metadata` for OpenAI, Claude, Azure, Gemini
- Judge logs now get token usage on successful structured questions (not just generate)

### Gemini-specific
- `json_schema` structured output with `include_raw`
- Parse-failure diagnostics: `structured_output_debug` (`raw_content`, `parsed_type`, etc.) via `_on_structured_error` → judge log files
- Bounded logging helpers (`_truncate_for_log`, `_serialize_raw_message`) with clearer docstrings

### Tests
- Unit tests for logging helpers (`test_logging_utils.py`)
- Cross-provider test on `TestJudgeLLMBase`: structured output captures usage from raw (OpenAI, Claude, Azure, Gemini)
- Gemini tests for unparsed structured output, stale debug on retry, etc.
- Shared structured-output test helpers in `test_helpers.py`

### Docs / naming
- Toy example on `extract_structured_invoke_result`
- Clarified `_serialize_raw_message` vs `raw_content` split
- Renamed `coerced` → `pydantic_response` / `ensure_pydantic_response`