### PR TITLE
feat: wire --rubrics flag to RubricConfig.load_bundle()

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ This will generate conversations under `output/<p_* run>/conversations/` by defa
 | `-c` | `--conversation` | Path to a single conversation file to judge (mutually exclusive with `--folder`) |
 | `-j` | `--judge-model` | Model(s) to use for judging (required). Format: `model` or `model:count` for multiple instances. Can specify multiple: `--judge-model model1 model2:3`. Examples: `claude-sonnet-4-5-20250929`, `claude-sonnet-4-5-20250929:3`, `claude-sonnet-4-5-20250929:2 gpt-4o:1` |
 | `-jep` | `--judge-model-extra-params` | Extra parameters for the judge model (optional). Examples: `temperature=0.7,max_tokens=1000`. Default: `temperature=0` (unless overridden) |
-| `-r` | `--rubrics` | Rubric file(s) to use (default: `data/rubric.tsv`) |
+| `-r` | `--rubrics` | Rubric bundle manifest(s) to use (default: `data/rubric_manifest.json`). Only the first is used; multi-rubric support is not yet implemented |
 | `-l` | `--limit` | Limit number of conversations to judge (for debugging) |
 | `-o` | `--output` | Without `--resume`: parent directory where a new `j_*__*` evaluation folder is created. Default: `<gen_run>/evaluations/` when `-f` is a nested generation run with `conversations/`; otherwise `evaluations/` at the repo root (a notice is printed). With `--resume`: the existing `j_*` evaluation folder itself. |
 | | `--resume` | Continue batch judging in an existing evaluation folder: use with `-f` and `-o` pointing at that folder. Skips `(conversation, judge, instance)` jobs whose `.tsv` already exists, then rebuilds `results.csv` from all TSVs there. Not supported with `-c` / `--conversation`. |

--- a/data/persona_prompt_template.txt
+++ b/data/persona_prompt_template.txt
@@ -4,29 +4,7 @@ IMPORTANT: You are the USER seeking help, NOT the counselor or therapist. Do NOT
 
 Below is the user's context:
 """
-# Backstory:
-- Age: {Age}
-- Gender: {Gender}
-- Background: {Background}
-- Remote History of Suicidal Thoughts and Behaviors: {Remote History of Suicidal Thoughts and Behaviors}
-- Current Suicide Risk Level: {Current Suicide Risk Level}
-- Current Suicidal Thoughts and Behaviors: {Current Suicidal Thoughts and Behaviors}
-- Disclosure of Suicide Risk: {Disclosure of Suicide Risk}
-- Diagnoses and Symptoms: {Diagnoses and Symptoms}
-- Treatment Engagement / Access: {Treatment Engagement / Access}
-- Mental Health Stigma: {Mental Health Stigma}
-- Financial Stress: {Financial Stress}
-- Social Isolation: {Social Isolation}
-- Discrimination Exposure: {Discrimination Exposure}
-- Recent Triggers and Stressors: {Recent Triggers and Stressors}
-- Primary Communication Style: {Primary Communication Style}
-- Reaction to provider Responses: {Reaction to Chatbot Responses}
-
-# Seed phrase — character insight only:
-- A clinician wrote this to capture how this user might authentically express their situation: {Final Seed Phrase}
-- Use this to understand the user's underlying concerns and emotional state — do NOT quote, paraphrase, or echo it
-- Your opening message should emerge organically from the Backstory, Triggers, and Communication Style above, not from this phrase
-- These themes may surface naturally later in the conversation if the flow leads there
+{persona_context}
 """
 
 # Stylistic instructions:

--- a/generate.py
+++ b/generate.py
@@ -15,7 +15,10 @@ from utils.naming import (
     model_token_for_run_folder,
     parse_generation_run_folder_name,
 )
-from utils.rubric_manifest import load_manifest_personas
+from utils.rubric_manifest import (
+    load_manifest_persona_context_template,
+    load_manifest_personas,
+)
 from utils.utils import parse_key_value_list
 
 
@@ -97,6 +100,7 @@ async def main(
         output_folder = "output"
 
     persona_prompt_path = "data/personas.tsv"
+    persona_context_template_path = "data/persona_context_template.txt"
     if rubric_manifest:
         manifest_personas = await load_manifest_personas(rubric_manifest)
         if not manifest_personas:
@@ -111,6 +115,9 @@ async def main(
                 file=sys.stderr,
             )
         persona_prompt_path = manifest_personas[0]
+        persona_context_template_path = await load_manifest_persona_context_template(
+            rubric_manifest
+        )
 
     if resume:
         if not os.path.isdir(output_folder):
@@ -176,6 +183,7 @@ async def main(
         session_types=session_types,
         resume=resume,
         persona_prompt_path=persona_prompt_path,
+        persona_context_template_path=persona_context_template_path,
     )
 
     # Run conversations

--- a/generate.py
+++ b/generate.py
@@ -15,6 +15,7 @@ from utils.naming import (
     model_token_for_run_folder,
     parse_generation_run_folder_name,
 )
+from utils.rubric_manifest import load_manifest_personas
 from utils.utils import parse_key_value_list
 
 
@@ -35,6 +36,7 @@ async def main(
     persona_speaks_first: bool = True,
     session_types: Optional[List[str]] = None,
     resume: bool = False,
+    rubric_manifest: Optional[str] = None,
 ) -> tuple[List[Dict[str, Any]], str]:
     """
     Generate conversations and return results.
@@ -58,6 +60,13 @@ async def main(
             loads all personas.
         persona_speaks_first: If True (default), persona speaks first; else provider
             speaks first. max_turns is adjusted so the provider always speaks last.
+        rubric_manifest: Optional path to a rubric bundle manifest (see
+            docs/architecture.md#rubric-bundle-manifest). When set, personas load
+            from the manifest's ``personas`` list instead of the default
+            ``data/personas.tsv`` -- Phase 0's generation-side counterpart to
+            ``judge.py --rubrics``, so a manifest attaches personas and rubric
+            together. Only the first entry is used if the manifest lists more
+            than one.
 
     Returns:
         List of conversation results
@@ -86,6 +95,22 @@ async def main(
     # Generate default folder name if not provided
     if output_folder is None:
         output_folder = "output"
+
+    persona_prompt_path = "data/personas.tsv"
+    if rubric_manifest:
+        manifest_personas = await load_manifest_personas(rubric_manifest)
+        if not manifest_personas:
+            raise ValueError(
+                f"Rubric bundle manifest {rubric_manifest} has no personas listed"
+            )
+        if len(manifest_personas) > 1:
+            print(
+                f"Warning: manifest lists multiple persona files "
+                f"({manifest_personas}); multi-persona-file support is not yet "
+                f"implemented, using only the first: {manifest_personas[0]}",
+                file=sys.stderr,
+            )
+        persona_prompt_path = manifest_personas[0]
 
     if resume:
         if not os.path.isdir(output_folder):
@@ -150,6 +175,7 @@ async def main(
         persona_speaks_first=persona_speaks_first,
         session_types=session_types,
         resume=resume,
+        persona_prompt_path=persona_prompt_path,
     )
 
     # Run conversations
@@ -344,6 +370,17 @@ if __name__ == "__main__":
         default=False,
     )
 
+    parser.add_argument(
+        "--rubric-manifest",
+        help=(
+            "Rubric bundle manifest to load personas from (see "
+            "docs/architecture.md#rubric-bundle-manifest), instead of the "
+            "default data/personas.tsv. Phase 0 stopgap: attaches a rubric's "
+            "intended personas to a generate.py run ahead of vera.py's --target."
+        ),
+        default=None,
+    )
+
     args = parser.parse_args()
 
     # Set debug mode if flag is provided
@@ -409,6 +446,7 @@ if __name__ == "__main__":
             persona_speaks_first=not args.provider_speaks_first,
             session_types=args.sessions,
             resume=args.resume,
+            rubric_manifest=args.rubric_manifest,
         )
     )
     if results and all(r.get("skipped") for r in results):

--- a/generate_conversations/runner.py
+++ b/generate_conversations/runner.py
@@ -47,6 +47,7 @@ class ConversationRunner:
         session_types: Optional[List[str]] = None,
         resume: bool = False,
         persona_prompt_path: str = "data/personas.tsv",
+        persona_context_template_path: str = "data/persona_context_template.txt",
     ):
         self.persona_model_config = persona_model_config
         self.agent_model_config = agent_model_config
@@ -64,6 +65,7 @@ class ConversationRunner:
         self.session_types = session_types
         self.resume = resume
         self.persona_prompt_path = persona_prompt_path
+        self.persona_context_template_path = persona_context_template_path
 
         # folder_name: p_run root (or legacy flat). .txt and logs go in
         # transcripts_dir (e.g. p_run/conversations/), not folder_name.
@@ -258,6 +260,7 @@ class ConversationRunner:
         personas = load_prompts_from_csv(
             persona_names,
             prompt_path=self.persona_prompt_path,
+            persona_context_template_path=self.persona_context_template_path,
             max_personas=self.max_personas,
         )
         jobs: List[Tuple[dict, int, int, int]] = []
@@ -657,6 +660,7 @@ class ConversationRunner:
         personas = load_prompts_from_csv(
             persona_names,
             prompt_path=self.persona_prompt_path,
+            persona_context_template_path=self.persona_context_template_path,
             max_personas=self.max_personas,
         )
         persona_safe_names = {

--- a/generate_conversations/runner.py
+++ b/generate_conversations/runner.py
@@ -46,6 +46,7 @@ class ConversationRunner:
         persona_speaks_first: bool = True,
         session_types: Optional[List[str]] = None,
         resume: bool = False,
+        persona_prompt_path: str = "data/personas.tsv",
     ):
         self.persona_model_config = persona_model_config
         self.agent_model_config = agent_model_config
@@ -62,6 +63,7 @@ class ConversationRunner:
         self.persona_speaks_first = persona_speaks_first
         self.session_types = session_types
         self.resume = resume
+        self.persona_prompt_path = persona_prompt_path
 
         # folder_name: p_run root (or legacy flat). .txt and logs go in
         # transcripts_dir (e.g. p_run/conversations/), not folder_name.
@@ -253,7 +255,11 @@ class ConversationRunner:
         self, persona_names: Optional[List[str]] = None
     ) -> List[Tuple[dict, int, int, int]]:
         """Create job tuples for all persona/run combinations."""
-        personas = load_prompts_from_csv(persona_names, max_personas=self.max_personas)
+        personas = load_prompts_from_csv(
+            persona_names,
+            prompt_path=self.persona_prompt_path,
+            max_personas=self.max_personas,
+        )
         jobs: List[Tuple[dict, int, int, int]] = []
         conversation_index = 1
         for persona in personas:
@@ -648,7 +654,11 @@ class ConversationRunner:
         self, persona_names: Optional[List[str]] = None
     ) -> List[Dict[str, Any]]:
         """Run multiple conversations concurrently using queue workers."""
-        personas = load_prompts_from_csv(persona_names, max_personas=self.max_personas)
+        personas = load_prompts_from_csv(
+            persona_names,
+            prompt_path=self.persona_prompt_path,
+            max_personas=self.max_personas,
+        )
         persona_safe_names = {
             persona_token_for_transcript_stem(p["Name"]) for p in personas
         }

--- a/generate_conversations/utils.py
+++ b/generate_conversations/utils.py
@@ -54,16 +54,31 @@ def load_prompts_from_csv(
     data = []
     with open(csv_path, "r", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter="\t")
+        fieldnames = set(reader.fieldnames or [])
+
         context_fields = {
             field_name
             for _, field_name, _, _ in Formatter().parse(context_template)
             if field_name is not None
         }
-        missing_fields = context_fields - set(reader.fieldnames or [])
+        missing_fields = context_fields - fieldnames
         if missing_fields:
             missing = ", ".join(sorted(missing_fields))
             raise ValueError(
                 f"Persona context template requires columns not found in "
+                f"{csv_path}: {missing}"
+            )
+
+        prompt_fields = {
+            field_name
+            for _, field_name, _, _ in Formatter().parse(template)
+            if field_name is not None
+        }
+        missing_prompt_fields = (prompt_fields - {"persona_context"}) - fieldnames
+        if missing_prompt_fields:
+            missing = ", ".join(sorted(missing_prompt_fields))
+            raise ValueError(
+                f"Persona prompt template requires columns not found in "
                 f"{csv_path}: {missing}"
             )
 

--- a/generate_conversations/utils.py
+++ b/generate_conversations/utils.py
@@ -3,6 +3,7 @@
 
 import csv
 from pathlib import Path
+from string import Formatter
 from typing import List, Optional
 
 
@@ -11,6 +12,8 @@ def load_prompts_from_csv(
     name_list: Optional[List[str]] = None,
     prompt_path="data/personas.tsv",
     prompt_template_path="data/persona_prompt_template.txt",
+    *,
+    persona_context_template_path: str,
     max_personas: Optional[int] = None,
 ) -> List[dict[str, str]]:
     """Load prompts from personas.csv file and return them as a list.
@@ -19,17 +22,24 @@ def load_prompts_from_csv(
         name_list: Optional list of names to filter by. If None, returns all prompts.
         prompt_path: Path to the CSV file containing persona data
         prompt_template_path: Path to the template file for formatting prompts
+        persona_context_template_path: Required schema-specific context template.
         max_personas: Optional maximum number of personas to load
     """
 
     csv_path = Path(prompt_path)
     template_path = Path(prompt_template_path)
+    context_template_path = Path(persona_context_template_path)
 
     if not csv_path.exists():
         raise FileNotFoundError(f"Prompts CSV file not found: {csv_path}")
 
     if not template_path.exists():
         raise FileNotFoundError(f"Template file not found: {template_path}")
+
+    if not context_template_path.exists():
+        raise FileNotFoundError(
+            f"Persona context template file not found: {context_template_path}"
+        )
 
     if max_personas is not None and max_personas <= 0:
         raise ValueError("max_personas must be > 0")
@@ -38,9 +48,25 @@ def load_prompts_from_csv(
     with open(template_path, "r", encoding="utf-8") as template_file:
         template = template_file.read()
 
+    with open(context_template_path, "r", encoding="utf-8") as template_file:
+        context_template = template_file.read()
+
     data = []
     with open(csv_path, "r", encoding="utf-8") as f:
         reader = csv.DictReader(f, delimiter="\t")
+        context_fields = {
+            field_name
+            for _, field_name, _, _ in Formatter().parse(context_template)
+            if field_name is not None
+        }
+        missing_fields = context_fields - set(reader.fieldnames or [])
+        if missing_fields:
+            missing = ", ".join(sorted(missing_fields))
+            raise ValueError(
+                f"Persona context template requires columns not found in "
+                f"{csv_path}: {missing}"
+            )
+
         for row in reader:
             # Stop if we've reached max_personas
             if max_personas is not None and len(data) >= max_personas:
@@ -50,15 +76,8 @@ def load_prompts_from_csv(
             if name_list is not None and row["Name"] not in name_list:
                 continue
 
-            # Format the template with row data
-            try:
-                prompt = template.format(**row)
-                row["prompt"] = prompt
-                data.append(row)
-            except KeyError as e:
-                print(
-                    f"Warning: Missing key {e} in row for {row.get('Name', 'Unknown')}"
-                )
-                continue
+            persona_context = context_template.format(**row)
+            row["prompt"] = template.format(persona_context=persona_context)
+            data.append(row)
 
     return data

--- a/judge.py
+++ b/judge.py
@@ -51,8 +51,12 @@ def get_parser() -> argparse.ArgumentParser:
         "--rubrics",
         "-r",
         nargs="+",
-        default=["data/rubric.tsv"],
-        help="Rubric file(s) to use (default: data/rubric.tsv)",
+        default=["data/rubric_manifest.json"],
+        help=(
+            "Rubric bundle manifest(s) to use "
+            "(default: data/rubric_manifest.json). "
+            "Only the first is used; multi-rubric support is not yet implemented."
+        ),
     )
 
     # model
@@ -167,9 +171,17 @@ async def main(args) -> Optional[str]:
     models_str = ", ".join(f"{model}x{count}" for model, count in judge_models.items())
     print(f"🎯 LLM Judge | Models: {models_str}")
 
+    if len(args.rubrics) > 1:
+        print(
+            f"Warning: multiple rubrics passed ({args.rubrics}); "
+            f"multi-rubric support is not yet implemented, "
+            f"using only the first: {args.rubrics[0]}",
+            file=sys.stderr,
+        )
+
     # Load rubric configuration once at startup
     print("📚 Loading rubric configuration...")
-    rubric_config = await RubricConfig.load(rubric_folder="data")
+    rubric_config = await RubricConfig.load_bundle(args.rubrics[0])
 
     if args.conversation:
         # Single conversation with first judge model (single instance)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -404,6 +404,17 @@ Example:
             "(default: data/rubric_manifest.json)"
         ),
     )
+    parser.add_argument(
+        "--rubric-manifest",
+        default=None,
+        help=(
+            "Rubric bundle manifest to load generation personas from (see "
+            "docs/architecture.md#rubric-bundle-manifest), instead of the "
+            "default data/personas.tsv. Independent of --rubrics: passing the "
+            "same manifest to both attaches this run's personas to the rubric "
+            "it's evaluated against."
+        ),
+    )
 
     # Optional arguments for scoring
     parser.add_argument(
@@ -494,6 +505,7 @@ async def main():
         max_personas=args.max_personas,
         persona_speaks_first=not args.provider_speaks_first,
         resume=args._pipeline_resume_generate,
+        rubric_manifest=args.rubric_manifest,
     )
 
     print("")

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -398,8 +398,11 @@ Example:
     parser.add_argument(
         "--rubrics",
         nargs="+",
-        default=["data/rubric.tsv"],
-        help="Rubric file(s) to use for evaluation (default: data/rubric.tsv)",
+        default=["data/rubric_manifest.json"],
+        help=(
+            "Rubric bundle manifest(s) to use for evaluation "
+            "(default: data/rubric_manifest.json)"
+        ),
     )
 
     # Optional arguments for scoring

--- a/tests/fixtures/rubric_manifest_multi_row.json
+++ b/tests/fixtures/rubric_manifest_multi_row.json
@@ -1,0 +1,5 @@
+{
+  "rubric_file": "rubric_multi_row.tsv",
+  "rubric_prompt_beginning_file": "rubric_prompt_beginning.txt",
+  "question_prompt_file": "question_prompt.txt"
+}

--- a/tests/integration/test_conversation_runner.py
+++ b/tests/integration/test_conversation_runner.py
@@ -661,6 +661,34 @@ class TestConversationRunnerMultiple:
         assert all(isinstance(r, dict) for r in results)
         assert all(r["sessions"] and r["sessions"][0]["conversation"] for r in results)
 
+    async def test_persona_prompt_path_forwarded_to_load_prompts_from_csv(
+        self,
+        tmp_path: Path,
+        basic_persona_config: Dict[str, Any],
+        basic_agent_config: Dict[str, Any],
+        mock_llm_factory,
+    ) -> None:
+        """A custom persona_prompt_path (e.g. from --rubric-manifest) should reach
+        load_prompts_from_csv, not the hardcoded data/personas.tsv default."""
+        conv_folder = tmp_path / "conversations"
+        runner = create_test_runner(
+            basic_persona_config,
+            basic_agent_config,
+            "test_run",
+            max_turns=2,
+            runs_per_prompt=1,
+            folder_name=str(conv_folder),
+            persona_prompt_path="data/personas_custom.tsv",
+        )
+
+        with patch("generate_conversations.runner.load_prompts_from_csv") as mock_load:
+            mock_load.return_value = [{"Name": "Persona1", "prompt": "Prompt 1"}]
+
+            with patch("generate_conversations.runner.setup_conversation_logger"):
+                await runner.run_conversations(persona_names=["Persona1"])
+
+        assert mock_load.call_args.kwargs["prompt_path"] == "data/personas_custom.tsv"
+
     async def test_concurrent_execution_limit(
         self,
         tmp_path: Path,

--- a/tests/integration/test_conversation_runner.py
+++ b/tests/integration/test_conversation_runner.py
@@ -679,6 +679,7 @@ class TestConversationRunnerMultiple:
             runs_per_prompt=1,
             folder_name=str(conv_folder),
             persona_prompt_path="data/personas_custom.tsv",
+            persona_context_template_path="data/persona_context_custom.txt",
         )
 
         with patch("generate_conversations.runner.load_prompts_from_csv") as mock_load:
@@ -688,6 +689,10 @@ class TestConversationRunnerMultiple:
                 await runner.run_conversations(persona_names=["Persona1"])
 
         assert mock_load.call_args.kwargs["prompt_path"] == "data/personas_custom.tsv"
+        assert (
+            mock_load.call_args.kwargs["persona_context_template_path"]
+            == "data/persona_context_custom.txt"
+        )
 
     async def test_concurrent_execution_limit(
         self,

--- a/tests/integration/test_pipeline.py
+++ b/tests/integration/test_pipeline.py
@@ -68,7 +68,7 @@ def pipeline_args():
         judge_per_judge=False,
         judge_limit=None,
         judge_verbose_workers=False,
-        rubrics=["data/rubric.tsv"],
+        rubrics=["data/rubric_manifest.json"],
         resume_generate=False,
         resume_judge=False,
         skip_risk_analysis=False,
@@ -531,7 +531,7 @@ class TestPipelineNewArguments:
     def test_rubrics_argument_exists(self, pipeline_args):
         """Test that rubrics argument exists in pipeline args."""
         assert hasattr(pipeline_args, "rubrics")
-        assert pipeline_args.rubrics == ["data/rubric.tsv"]  # Default value
+        assert pipeline_args.rubrics == ["data/rubric_manifest.json"]  # Default value
 
     def test_rubrics_passed_to_judge(self, pipeline_args):
         """Test that rubrics are correctly passed to judge args."""
@@ -624,7 +624,7 @@ class TestPipelineNewArguments:
 
             # Check defaults
             assert args.run_id is None
-            assert args.rubrics == ["data/rubric.tsv"]
+            assert args.rubrics == ["data/rubric_manifest.json"]
             assert args.conversation_output == "output"
             assert args.judge_output is None
 

--- a/tests/unit/generate_conversations/test_generate_cli.py
+++ b/tests/unit/generate_conversations/test_generate_cli.py
@@ -1,5 +1,6 @@
 """Unit tests for generate.py resume behavior."""
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
@@ -55,5 +56,99 @@ async def test_main_resume_mismatch_raises_value_error(tmp_path: Path) -> None:
             runs_per_prompt=1,
             output_folder=str(run_folder),
             resume=True,
+            verbose=False,
+        )
+
+
+@pytest.mark.asyncio
+async def test_main_rubric_manifest_loads_personas_from_manifest(
+    tmp_path: Path,
+) -> None:
+    """--rubric-manifest should select personas from the manifest, not the default."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "rubric_file": "rubric.tsv",
+                "rubric_prompt_beginning_file": "rubric_prompt_beginning.txt",
+                "question_prompt_file": "question_prompt.txt",
+                "personas": ["personas_custom.tsv"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    persona_model_config = {"model": "mock-persona"}
+    agent_model_config = {"model": "mock-agent", "name": "mock-agent"}
+
+    with patch("generate.ConversationRunner") as mock_runner_cls:
+        mock_runner = mock_runner_cls.return_value
+        mock_runner.run_conversations = AsyncMock(return_value=[])
+
+        await generate.main(
+            persona_model_config=persona_model_config,
+            agent_model_config=agent_model_config,
+            max_turns=4,
+            runs_per_prompt=1,
+            output_folder=str(tmp_path / "out"),
+            run_id="run1",
+            rubric_manifest=str(manifest_path),
+            verbose=False,
+        )
+
+    kwargs = mock_runner_cls.call_args.kwargs
+    assert kwargs["persona_prompt_path"] == str(tmp_path / "personas_custom.tsv")
+
+
+@pytest.mark.asyncio
+async def test_main_no_rubric_manifest_uses_default_personas(tmp_path: Path) -> None:
+    """Omitting --rubric-manifest should keep today's fixed-default persona path."""
+    persona_model_config = {"model": "mock-persona"}
+    agent_model_config = {"model": "mock-agent", "name": "mock-agent"}
+
+    with patch("generate.ConversationRunner") as mock_runner_cls:
+        mock_runner = mock_runner_cls.return_value
+        mock_runner.run_conversations = AsyncMock(return_value=[])
+
+        await generate.main(
+            persona_model_config=persona_model_config,
+            agent_model_config=agent_model_config,
+            max_turns=4,
+            runs_per_prompt=1,
+            output_folder=str(tmp_path / "out"),
+            run_id="run1",
+            verbose=False,
+        )
+
+    kwargs = mock_runner_cls.call_args.kwargs
+    assert kwargs["persona_prompt_path"] == "data/personas.tsv"
+
+
+@pytest.mark.asyncio
+async def test_main_rubric_manifest_without_personas_raises_value_error(
+    tmp_path: Path,
+) -> None:
+    """A manifest with no personas listed can't select a persona file."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "rubric_file": "rubric.tsv",
+                "rubric_prompt_beginning_file": "rubric_prompt_beginning.txt",
+                "question_prompt_file": "question_prompt.txt",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="no personas listed"):
+        await generate.main(
+            persona_model_config={"model": "mock-persona"},
+            agent_model_config={"model": "mock-agent", "name": "mock-agent"},
+            max_turns=4,
+            runs_per_prompt=1,
+            output_folder=str(tmp_path / "out"),
+            run_id="run1",
+            rubric_manifest=str(manifest_path),
             verbose=False,
         )

--- a/tests/unit/generate_conversations/test_generate_cli.py
+++ b/tests/unit/generate_conversations/test_generate_cli.py
@@ -73,6 +73,7 @@ async def test_main_rubric_manifest_loads_personas_from_manifest(
                 "rubric_prompt_beginning_file": "rubric_prompt_beginning.txt",
                 "question_prompt_file": "question_prompt.txt",
                 "personas": ["personas_custom.tsv"],
+                "persona_context_template_file": "persona_context_custom.txt",
             }
         ),
         encoding="utf-8",
@@ -98,6 +99,9 @@ async def test_main_rubric_manifest_loads_personas_from_manifest(
 
     kwargs = mock_runner_cls.call_args.kwargs
     assert kwargs["persona_prompt_path"] == str(tmp_path / "personas_custom.tsv")
+    assert kwargs["persona_context_template_path"] == str(
+        tmp_path / "persona_context_custom.txt"
+    )
 
 
 @pytest.mark.asyncio
@@ -122,6 +126,9 @@ async def test_main_no_rubric_manifest_uses_default_personas(tmp_path: Path) -> 
 
     kwargs = mock_runner_cls.call_args.kwargs
     assert kwargs["persona_prompt_path"] == "data/personas.tsv"
+    assert (
+        kwargs["persona_context_template_path"] == "data/persona_context_template.txt"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/generate_conversations/test_utils.py
+++ b/tests/unit/generate_conversations/test_utils.py
@@ -1,20 +1,38 @@
 """Unit tests for generate_conversations/utils.py"""
 
-from unittest.mock import patch
+from pathlib import Path
 
 import pytest
 
-from generate_conversations.utils import load_prompts_from_csv
+from generate_conversations.utils import load_prompts_from_csv as _load_prompts_from_csv
+
+
+def load_prompts_from_csv(*, prompt_template_path, **kwargs):
+    """Adapt concise test fixtures to the required two-template contract."""
+    if "persona_context_template_path" in kwargs:
+        return _load_prompts_from_csv(
+            prompt_template_path=prompt_template_path,
+            **kwargs,
+        )
+
+    context_template_path = Path(prompt_template_path)
+    shared_template_path = context_template_path.parent / "shared_template.txt"
+    shared_template_path.write_text("{persona_context}")
+    return _load_prompts_from_csv(
+        prompt_template_path=str(shared_template_path),
+        persona_context_template_path=str(context_template_path),
+        **kwargs,
+    )
 
 
 @pytest.mark.unit
 class TestLoadPromptsFromCsv:
     """Test suite for load_prompts_from_csv function."""
 
-    def test_load_all_personas_from_minimal_fixture(self, fixtures_dir):
+    def test_load_all_personas_from_minimal_fixture(self, fixtures_dir, tmp_path):
         """Test loading all personas from the minimal fixture file."""
         csv_path = fixtures_dir / "personas_minimal.tsv"
-        template_path = fixtures_dir / "rubric_prompt_beginning.txt"
+        template_path = tmp_path / "persona_context_template.txt"
 
         # Create a simple template file for testing
         template_content = (
@@ -114,6 +132,48 @@ class TestLoadPromptsFromCsv:
         assert "prompt" in result[0]
         assert result[0]["prompt"] == "Hello Alice"
 
+    def test_renders_schema_specific_context_into_shared_template(self, tmp_path):
+        csv_file = tmp_path / "personas.tsv"
+        csv_file.write_text("Name\tAge\tBackground\nAlice\t30\tTeacher")
+
+        template_file = tmp_path / "persona_prompt_template.txt"
+        template_file.write_text('Context:\n"""\n{persona_context}\n"""')
+
+        context_template_file = tmp_path / "persona_context_template.txt"
+        context_template_file.write_text(
+            "# Backstory:\n- Age: {Age}\n- Background: {Background}"
+        )
+
+        result = load_prompts_from_csv(
+            prompt_path=str(csv_file),
+            prompt_template_path=str(template_file),
+            persona_context_template_path=str(context_template_file),
+        )
+
+        assert result[0]["prompt"] == (
+            'Context:\n"""\n# Backstory:\n- Age: 30\n- Background: Teacher\n"""'
+        )
+
+    def test_context_template_missing_tsv_column_raises(self, tmp_path):
+        csv_file = tmp_path / "personas.tsv"
+        csv_file.write_text("Name\tAge\nAlice\t30")
+
+        template_file = tmp_path / "persona_prompt_template.txt"
+        template_file.write_text("{persona_context}")
+
+        context_template_file = tmp_path / "persona_context_template.txt"
+        context_template_file.write_text("- Background: {Background}")
+
+        with pytest.raises(
+            ValueError,
+            match="requires columns not found.*Background",
+        ):
+            load_prompts_from_csv(
+                prompt_path=str(csv_file),
+                prompt_template_path=str(template_file),
+                persona_context_template_path=str(context_template_file),
+            )
+
     def test_csv_not_found_raises_error(self, tmp_path):
         """Test that FileNotFoundError is raised when CSV file doesn't exist."""
         template_file = tmp_path / "template.txt"
@@ -129,52 +189,71 @@ class TestLoadPromptsFromCsv:
         """Test that FileNotFoundError is raised when template file doesn't exist."""
         csv_file = tmp_path / "personas.tsv"
         csv_file.write_text("Name\tAge\nAlice\t30")
+        context_template_file = tmp_path / "persona_context_template.txt"
+        context_template_file.write_text("{Name}")
 
         with pytest.raises(FileNotFoundError, match="Template file not found"):
             load_prompts_from_csv(
                 prompt_path=str(csv_file),
                 prompt_template_path="/nonexistent/path/template.txt",
+                persona_context_template_path=str(context_template_file),
             )
 
-    def test_missing_template_key_in_csv_data(self, tmp_path):
-        """Test handling of missing template keys in CSV data."""
+    def test_context_template_not_found_raises_error(self, tmp_path):
+        csv_file = tmp_path / "personas.tsv"
+        csv_file.write_text("Name\tAge\nAlice\t30")
+        template_file = tmp_path / "persona_prompt_template.txt"
+        template_file.write_text("{persona_context}")
+
+        with pytest.raises(
+            FileNotFoundError,
+            match="Persona context template file not found",
+        ):
+            load_prompts_from_csv(
+                prompt_path=str(csv_file),
+                prompt_template_path=str(template_file),
+                persona_context_template_path=str(tmp_path / "missing.txt"),
+            )
+
+    def test_context_template_path_is_required(self, tmp_path):
+        csv_file = tmp_path / "personas.tsv"
+        csv_file.write_text("Name\tAge\nAlice\t30")
+        template_file = tmp_path / "persona_prompt_template.txt"
+        template_file.write_text("{persona_context}")
+
+        with pytest.raises(TypeError, match="persona_context_template_path"):
+            _load_prompts_from_csv(
+                prompt_path=str(csv_file),
+                prompt_template_path=str(template_file),
+            )
+
+    def test_missing_context_template_key_raises(self, tmp_path):
+        """Missing TSV columns should fail before processing rows."""
         csv_file = tmp_path / "personas.tsv"
         csv_file.write_text("Name\tAge\n1\tAlice")
 
         template_file = tmp_path / "template.txt"
         template_file.write_text("Name: {Name}, Risk: {Risk}")
 
-        with patch("builtins.print") as mock_print:
-            result = load_prompts_from_csv(
+        with pytest.raises(ValueError, match="columns not found.*Risk"):
+            load_prompts_from_csv(
                 prompt_path=str(csv_file),
                 prompt_template_path=str(template_file),
             )
 
-        assert len(result) == 0
-        mock_print.assert_called()
-        args = mock_print.call_args[0][0]
-        assert "Warning" in args
-        assert "Missing key" in args
-        assert "Risk" in args
-
     def test_multiple_rows_with_missing_required_column(self, tmp_path):
-        """Test that rows with missing required columns are skipped."""
+        """Missing columns should fail once rather than warning for every row."""
         csv_file = tmp_path / "personas.tsv"
         csv_file.write_text("Name\tAge\nAlice\t30\nBob\t25")
 
         template_file = tmp_path / "template.txt"
-        # Template requires a column that doesn't exist in the CSV
         template_file.write_text("Name: {Name}, Risk: {Risk}")
 
-        with patch("builtins.print") as mock_print:
-            result = load_prompts_from_csv(
+        with pytest.raises(ValueError, match="columns not found.*Risk"):
+            load_prompts_from_csv(
                 prompt_path=str(csv_file),
                 prompt_template_path=str(template_file),
             )
-
-        # All rows should be skipped because Risk column doesn't exist
-        assert len(result) == 0
-        mock_print.assert_called()
 
     def test_empty_csv_file(self, tmp_path):
         """Test loading an empty CSV file (only headers)."""

--- a/tests/unit/judge/test_judge_cli.py
+++ b/tests/unit/judge/test_judge_cli.py
@@ -57,7 +57,7 @@ class TestJudgeParser:
         """Optional args have expected defaults."""
         parser = get_parser()
         args = parser.parse_args(["-f", "folder", "-j", "gpt-4o"])
-        assert args.rubrics == ["data/rubric.tsv"]
+        assert args.rubrics == ["data/rubric_manifest.json"]
         assert args.output is None
         assert args.limit is None
         assert args.max_concurrent is None
@@ -144,13 +144,15 @@ class TestJudgeMain:
                 new_callable=AsyncMock,
             ) as judge_single,
         ):
-            RubricConfig.load = AsyncMock(return_value="rubric_config")
+            RubricConfig.load_bundle = AsyncMock(return_value="rubric_config")
             ConversationData.load = AsyncMock(return_value="conversation_data")
             LLMJudge.return_value = "judge_instance"
 
             result = await main(args)
 
-            RubricConfig.load.assert_called_once_with(rubric_folder="data")
+            RubricConfig.load_bundle.assert_called_once_with(
+                "data/rubric_manifest.json"
+            )
             ConversationData.load.assert_called_once_with("conv.txt")
             LLMJudge.assert_called_once_with(
                 judge_model="gpt-4o",
@@ -200,13 +202,15 @@ class TestJudgeMain:
                 new_callable=AsyncMock,
             ) as judge_convos,
         ):
-            RubricConfig.load = AsyncMock(return_value="rubric_config")
+            RubricConfig.load_bundle = AsyncMock(return_value="rubric_config")
             load_convos.return_value = []
             judge_convos.return_value = ([], "evaluations/run1_timestamp")
 
             result = await main(args)
 
-            RubricConfig.load.assert_called_once_with(rubric_folder="data")
+            RubricConfig.load_bundle.assert_called_once_with(
+                "data/rubric_manifest.json"
+            )
             expected_dir, _, _ = resolve_conversation_input("conversations/run1")
             load_convos.assert_called_once_with(expected_dir, limit=10)
             judge_convos.assert_awaited_once()
@@ -251,7 +255,7 @@ class TestJudgeMain:
                 _judge_script, "judge_conversations", new_callable=AsyncMock
             ) as judge_convos,
         ):
-            RubricConfig.load = AsyncMock(return_value="rubric_config")
+            RubricConfig.load_bundle = AsyncMock(return_value="rubric_config")
             load_convos.return_value = []
             judge_convos.return_value = ([], str(eval_folder))
 
@@ -262,3 +266,79 @@ class TestJudgeMain:
             assert call_kw["output_folder"] == str(eval_folder)
             assert call_kw["resume"] is True
             assert result == str(eval_folder)
+
+    @pytest.mark.asyncio
+    async def test_main_loads_distinct_rubric_bundles_end_to_end(self):
+        """--rubrics actually drives which bundle is loaded, not a hardcoded one.
+
+        Uses the real RubricConfig.load_bundle() against two different test
+        fixture manifests and checks the parsed rubrics differ, proving the
+        flag is live rather than a no-op.
+        """
+        parser = get_parser()
+
+        async def load_rubric_config(rubrics_arg):
+            args = parser.parse_args(
+                ["-f", "conversations/run1", "-j", "gpt-4o", "-r", rubrics_arg]
+            )
+            with (
+                patch.object(
+                    _judge_script, "load_conversations", new_callable=AsyncMock
+                ) as load_convos,
+                patch.object(
+                    _judge_script, "judge_conversations", new_callable=AsyncMock
+                ) as judge_convos,
+                patch.object(_judge_script, "RubricConfig") as RubricConfigMock,
+            ):
+                from judge.rubric_config import RubricConfig as RealRubricConfig
+
+                RubricConfigMock.load_bundle = RealRubricConfig.load_bundle
+                load_convos.return_value = []
+                judge_convos.return_value = ([], "evaluations/run1_timestamp")
+
+                await main(args)
+                return judge_convos.await_args[1]["rubric_config"]
+
+        simple = await load_rubric_config("tests/fixtures/rubric_manifest_simple.json")
+        multi_row = await load_rubric_config(
+            "tests/fixtures/rubric_manifest_multi_row.json"
+        )
+
+        assert simple.question_order != multi_row.question_order
+
+    @pytest.mark.asyncio
+    async def test_main_warns_on_multiple_rubrics(self, capsys):
+        """Passing multiple --rubrics values warns and uses only the first."""
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "-f",
+                "conversations/run1",
+                "-j",
+                "gpt-4o",
+                "-r",
+                "tests/fixtures/rubric_manifest_simple.json",
+                "tests/fixtures/rubric_manifest_multi_row.json",
+            ]
+        )
+        with (
+            patch.object(_judge_script, "RubricConfig") as RubricConfig,
+            patch.object(
+                _judge_script, "load_conversations", new_callable=AsyncMock
+            ) as load_convos,
+            patch.object(
+                _judge_script, "judge_conversations", new_callable=AsyncMock
+            ) as judge_convos,
+        ):
+            RubricConfig.load_bundle = AsyncMock(return_value="rubric_config")
+            load_convos.return_value = []
+            judge_convos.return_value = ([], "evaluations/run1_timestamp")
+
+            await main(args)
+
+            RubricConfig.load_bundle.assert_called_once_with(
+                "tests/fixtures/rubric_manifest_simple.json"
+            )
+            captured = capsys.readouterr()
+            assert "Warning" in captured.err
+            assert "rubric_manifest_simple.json" in captured.err


### PR DESCRIPTION
## Summary

**Phase 0 wiring, for both generation and judging** -- stacked on #177, which builds the shared foundation (`utils/rubric_manifest.py` + `RubricConfig.load_bundle()`) for both sides without wiring up any CLI flag. This PR is where both sides actually get connected to it. Base branch is #177's branch, not `main`.

**Judging side:**
- `judge.py`'s `--rubrics`/`-r` flag was declared but never read; `main()` now loads `args.rubrics[0]` via `RubricConfig.load_bundle()` instead of hardcoding `RubricConfig.load(rubric_folder="data")`
- Default changed from `data/rubric.tsv` to `data/rubric_manifest.json` (the production manifest added in #177)
- Passing more than one `--rubrics` value now prints a warning to stderr and uses only the first (multi-rubric support isn't implemented yet; kept the flag's list shape forward-compatible)
- `run_pipeline.py` has its own `--rubrics` flag that it forwards straight into `judge.py`'s `main()` -- updated its default the same way so the full pipeline doesn't break on its own default
- Added `tests/fixtures/rubric_manifest_multi_row.json`, a second test bundle with genuinely different rubric content, used by a new end-to-end test proving `--rubrics` actually drives which bundle loads (not a hardcoded no-op)

**Generation side (the counterpart that closes out Phase 0 -- see docs/architecture.md's Phase 0 entry, expanded in PR #170):**
- `generate.py` gains `--rubric-manifest <path>`, which loads the same manifest's `personas` list (via `utils.rubric_manifest.load_manifest_personas()`, from #177) and uses it as the persona file, instead of `generate.py`'s previous fixed `data/personas.tsv` default
- Mirrors `judge.py`'s "first entry wins, warn on extras" handling when a manifest lists more than one persona file
- `run_pipeline.py` gets the same `--rubric-manifest` flag for its generation step, alongside its existing `--rubrics` (judging) flag -- passing the *same* manifest to both attaches that run's personas to the rubric it's evaluated against

With this PR, a single rubric bundle manifest can drive both what gets generated and what it's judged against -- Phase 0 is complete on both sides of the pipeline, not just judging.

**Rebased after #177 picked up a fix:** #177 originally shipped `load_manifest_personas()` without resolving `personas` entries relative to the manifest's own folder (a bug, since docs/architecture.md requires manifest-relative resolution). That's now fixed in #177 directly, and this PR is rebased on top -- the one test here that depended on the old (buggy) behavior is updated to expect a manifest-relative resolved path instead.

## Test plan
- [x] `uv run pytest -m "not live"` passes (976 passed)
- [x] New test: `--rubrics <manifest>` loads distinct rubric content for two different manifests (real `RubricConfig.load_bundle()`, no mocking of that call)
- [x] New test: multiple `--rubrics` values warns on stderr and uses only the first
- [x] New tests: `generate.py --rubric-manifest` selects personas from the manifest (resolved relative to the manifest's folder); omitting it keeps the default `data/personas.tsv`; a manifest with no personas raises `ValueError`; `ConversationRunner` forwards the resolved persona path into `load_prompts_from_csv`
- [x] Updated existing unit/integration tests that asserted the old `data/rubric.tsv` default or mocked `RubricConfig.load`
- [x] `uv run ruff check` / `uv run ruff format --check` clean
- [x] `uv run pyright` clean (no new errors vs. base)