### PR TITLE
docs: define design record conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,12 @@ cp .env.example .env       # Add API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, et
 
 Read [docs/architecture.md](docs/architecture.md) before structural changes. See its [ESCALATE section](docs/architecture.md#escalate-stop-and-ask) for when to stop and ask, and [Enforcement](docs/architecture.md#enforcement) for the pre-push verification commands.
 
+When an architecture escalation requires a design record, create it under
+[`docs/design/`](docs/design/) and follow the required format and lifecycle in
+[`docs/design/README.md`](docs/design/README.md). Keep current normative rules in
+the architecture documentation; design records preserve rationale and
+consequences without duplicating that contract.
+
 ## Testing
 
 The project uses [pytest](https://docs.pytest.org/) with unit and integration tests under `tests/`. Coverage is enforced (`--cov-fail-under=30` in `pyproject.toml`).
@@ -169,6 +175,7 @@ One canonical home per concern — cross-link, don't copy paragraphs.
 |-----|----------|---------|
 | [README.md](./README.md) | Humans | Setup, CLI usage, output layout |
 | [docs/architecture.md](./docs/architecture.md) | Humans and agents | Target architecture, invariants, layer model |
+| [docs/design/](./docs/design/) | Humans and agents | Historical design decisions, rationale, and compatibility consequences |
 | **AGENTS.md** (this file) | All coding agents | Style, architecture map, testing, key commands, git conventions |
 | [CLAUDE.md](./CLAUDE.md) | Claude Code only | Slash commands, `.claude/` maintenance |
 | [docs/](./docs/) | Humans and agents | Topic deep dives (see links below) |
@@ -180,6 +187,7 @@ One canonical home per concern — cross-link, don't copy paragraphs.
 ### Links
 
 - **Architecture:** [docs/architecture.md](docs/architecture.md)
+- **Design decision records:** [docs/design/README.md](docs/design/README.md)
 - **Setup, pipeline, output layout:** [README.md](./README.md)
 - **Custom LLM providers:** [docs/evaluating.md](./docs/evaluating.md)
 - **Judge behavior:** [docs/judge.md](./docs/judge.md)

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -1,0 +1,65 @@
+# Design decision records
+
+This directory contains short records of architectural decisions that need to
+survive beyond the pull request where they were made. A record explains why a
+decision was necessary, what was chosen, and what consequences were accepted.
+It is not a second copy of the current architecture.
+
+## When to add a record
+
+Add a design record when required by the
+[architecture escalation rules](../architecture.md#escalate-stop-and-ask),
+including changes to a stable interface, or when a decision has consequences
+that future maintainers would not be able to recover from the code alone. Do not
+create one for routine implementation choices.
+
+## Canonical documentation
+
+- [Architecture](../architecture.md) defines the current normative structure and
+  invariants.
+- [CLI use cases](../vera-cli-use-cases.md) define user-facing behavior and
+  examples.
+- Design records preserve context, rationale, alternatives, and consequences.
+
+Link to canonical documentation instead of copying its rules into a design
+record. If the architecture changes later, add a new record and supersede the
+old one rather than rewriting history.
+
+## Required format
+
+Use a descriptive, kebab-case filename and one decision per file:
+
+```markdown
+# Decision title
+
+Status: Proposed | Accepted | Rejected | Superseded
+Date: YYYY-MM-DD
+
+## Context
+
+Why a decision is needed.
+
+## Decision
+
+What was chosen, including links to canonical architecture where appropriate.
+
+## Consequences
+
+Compatibility effects, tradeoffs, migration requirements, and known risks.
+
+## Superseded by
+
+Optional. Link to the replacement record when Status is Superseded.
+```
+
+## Lifecycle
+
+- A `Proposed` record may change during review.
+- An `Accepted` or `Rejected` record is historical. Fix broken links or factual
+  errors, but do not rewrite its decision to match later implementation.
+- When a decision changes materially, add a new record, set the old record to
+  `Superseded`, and link the two records.
+- Keep accepted, rejected, and superseded records in this directory; their value
+  is the history they preserve.
+- Link the relevant record from any pull request that changes a protected stable
+  interface.


### PR DESCRIPTION
## Summary

- explain the purpose and lifecycle of design decision records
- define a lightweight required format for proposed, accepted, rejected, and superseded decisions
- direct coding agents to use the convention for architecture escalations

## Validation

- `git diff --check`