### PR TITLE
fix: pin dotenv path and keep real credentials out of tests

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,3 +2,20 @@
 - better logging system
 - why async judges are not async?
 - printing at the beginning to confirm settings. LLM class should return the actual model used
+- move load_dotenv() out of import time in llm_clients/config.py, and read API
+  keys lazily instead of as class attributes.
+  Today importing llm_clients.config has the side effect of loading .env, and
+  Config.ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY etc. are evaluated
+  once at class-definition time, so the values freeze on first import. That is
+  why tests/unit/llm_clients/test_config.py has to call importlib.reload(config)
+  to observe a patched environment.
+  Fix: call load_dotenv() explicitly from the CLI entry points (generate.py,
+  judge.py, run_pipeline.py) rather than at import, and turn the Config key
+  attributes into properties or a classmethod so each read consults os.environ.
+  Scope: only 14 Config.<ATTR> uses in source (8 of them in
+  llm_clients/azure_llm.py), but ~92 in tests, plus unwinding the reload
+  pattern. Worth its own PR off main; it does not depend on the CircleCI work.
+  Two partial mitigations already landed, so this is a cleanup and not urgent:
+  the .env path is pinned to the repo so the search cannot escape into ~/.env,
+  and an autouse fixture in tests/conftest.py replaces real provider
+  credentials with dummies outside live tests.

--- a/llm_clients/config.py
+++ b/llm_clients/config.py
@@ -9,11 +9,17 @@ Design Philosophy:
 """
 
 import os
+from pathlib import Path
 from typing import Any, Dict, Optional
 
 from dotenv import load_dotenv
 
-load_dotenv()
+# Load this repository's own .env, and only that file. A bare load_dotenv()
+# searches upward from this file until it finds a .env anywhere above it, so a
+# checkout without one (a git worktree, for example) silently picks up an
+# unrelated .env from an ancestor directory such as ~/.env. Naming the path
+# keeps the result the same no matter where the code is checked out or run from.
+load_dotenv(Path(__file__).resolve().parent.parent / ".env")
 
 
 class Config:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,40 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
     _adhoc_temp = None
 
 
+_CREDENTIAL_ENV_VARS = (
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GEMINI_API_KEY",
+    "AZURE_API_KEY",
+    "AZURE_OPENAI_API_KEY",
+    "ENDPOINT_API_KEY",
+)
+
+_DUMMY_CREDENTIAL = "test-dummy-not-a-real-key"
+
+
+@pytest.fixture(autouse=True)
+def no_real_credentials(request: pytest.FixtureRequest, monkeypatch) -> None:
+    """Replace real provider credentials with dummies outside live tests.
+
+    llm_clients.config calls load_dotenv() at import time, so a developer's real
+    keys are present in os.environ during the suite. A test missing the `live`
+    marker would therefore make real, billable API calls locally and only fail in
+    CI, where no keys exist. This also covers the gap in --disable-socket, which
+    cannot see into the subprocesses the live tests spawn, since children inherit
+    this environment.
+
+    The values are overwritten rather than deleted on purpose: importlib.reload
+    on the config module re-runs load_dotenv(), which would repopulate a deleted
+    variable from .env but leaves an existing one alone.
+    """
+    if "live" in request.keywords:
+        return
+    for var in _CREDENTIAL_ENV_VARS:
+        monkeypatch.setenv(var, _DUMMY_CREDENTIAL)
+
+
 @pytest.fixture
 def fixtures_dir() -> Path:
     """Path to test fixtures directory."""


### PR DESCRIPTION
## Summary

Two hardening changes around the import-time `load_dotenv()` in `llm_clients/config.py`. Fourth in the CircleCI stack — base is #204.

**1. Pin the `.env` path.** A bare `load_dotenv()` calls `find_dotenv()`, which walks *up* from `config.py` until it finds a `.env` anywhere above it, stopping only at the filesystem root. So a checkout without its own `.env` silently loads an unrelated one from an ancestor directory. This is not hypothetical — **7 of 8 local git worktrees of this repo resolve to `~/.env`**, pulling in credentials from another project:

```
$ cd VERA-MH-feat-vera-cli && python -c "from dotenv import find_dotenv; print(find_dotenv())"
/Users/luca.belli/.env
```

Naming the path explicitly makes the result identical regardless of where the code is checked out or run from: this repo's `.env`, or nothing.

**2. Keep real credentials out of non-live tests.** Because `config.py` loads `.env` at import, a developer's real keys sit in `os.environ` for the whole suite. A test missing the `live` marker therefore makes real, billable API calls locally and fails only in CI, where no keys exist — so the breakage surfaces far from its cause and reads as a CI problem rather than a missing marker. An autouse fixture replaces the 7 provider credential vars with a dummy unless the test is marked `live`.

This also closes the known gap in the `--disable-socket` guard from #204, which cannot see into the subprocesses the live tests spawn via `subprocess.run` — child processes inherit this scrubbed environment.

### One subtlety worth reviewing

The fixture **overwrites rather than deletes**, deliberately. `load_dotenv()` does not override a variable that is already set, but it *does* fill in a missing one — so a deleted key would be quietly restored from `.env` by the `importlib.reload(config)` calls in `tests/unit/llm_clients/test_config.py`. An overwritten one survives. Deleting would have looked correct and silently failed.

### Not fixed here

The root cause remains: importing `llm_clients.config` loads `.env` as a side effect, and the `Config` key attributes are evaluated once at class-definition time, so values freeze on first import. That is what forces the `importlib.reload` dance in the tests. Fixing it means moving `load_dotenv()` into the CLI entry points and making the keys lazy — 14 `Config.<ATTR>` uses in source, but ~92 in tests. Recorded in `TODO` (second commit) as its own PR off `main`, since it does not depend on this stack.

## Architecture checklist

- [ ] Read [architecture.md](docs/architecture.md)
- [ ] OpenSpec change linked (required for multi-file or cross-boundary work) — n/a, no boundary changes
- [x] `uv run pyright` passes — 0 errors on both changed files (`pyright llm_clients/config.py tests/conftest.py`). The repo-wide run reports 416 pre-existing errors, unchanged by this PR, which is why CI keeps `continue-on-error` on that step.
- [x] `uv run pytest -m "not live"` passes — 972 passed, 8 deselected, 75% coverage
- [ ] Label **`architecture-change`** — not needed; no boundaries, entry points, or dependencies changed

## Test plan

- [x] Local checks run — full non-live suite, `ruff format --check` and `ruff check` clean over the tracked set
- [ ] CI green — **cannot be verified yet.** GitHub Actions is disabled on this repo (`gh api repos/SpringCare/VERA-MH/actions/permissions` → `enabled: false`), and CircleCI is not connected until #202 merges and the project is set up in the CircleCI UI. Expect zero checks reported on this PR.

Verified instead with temporary probes (written, run, deleted — not committed):

| Probe | Result |
|---|---|
| non-live test reads `OPENAI_API_KEY` | dummy value ✓ |
| dummy survives `importlib.reload(config)`, incl. `Config.OPENAI_API_KEY` | dummy value ✓ |
| `live`-marked test reads `OPENAI_API_KEY` | real environment ✓ |
