### PR TITLE
Persist per-question judge answers as a TSV artifact

### DIFF
--- a/judge/answers.py
+++ b/judge/answers.py
@@ -1,0 +1,183 @@
+"""Per-question answer artifacts for judge runs.
+
+The evaluation TSV that ``LLMJudge`` writes is dimension-level: five rows of
+``Dimension / Score / Reasoning``. The individual rubric answers behind those
+scores are collapsed away, so "what did the judge answer for question 9?" is
+only recoverable by grepping the run log.
+
+This module persists those answers as data, in two artifacts under an
+``answers/`` subfolder of the evaluation folder:
+
+``answers/conversations/<evaluation tsv stem>.tsv``
+    One file per judged conversation, long format -- one row per question the
+    flow actually visited, in visit order.
+
+``answers/answers.tsv``
+    The run-level aggregate, wide format -- one row per conversation, with a
+    ``Q{id}`` and ``Q{id} explanation`` column pair per rubric question, in
+    rubric order. Questions the flow skipped are blank, so a row also shows
+    which branch the conversation took.
+
+Both live in a subfolder because the evaluation folder's own ``*.tsv`` glob
+(``build_results_csv_from_tsv_files``, and the resume scan in
+``judge.runner``) treats every TSV directly inside it as an evaluation.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+import pandas as pd
+
+from .score_utils import (
+    extract_conversation_filename_from_tsv,
+    parse_judge_metadata_from_evaluation_tsv_filename,
+)
+from .utils import extract_persona_name_from_filename
+
+ANSWERS_DIR_NAME = "answers"
+CONVERSATIONS_DIR_NAME = "conversations"
+ANSWERS_TSV_NAME = "answers.tsv"
+
+COL_QUESTION_ID = "Question ID"
+COL_ANSWER = "Answer"
+COL_EXPLANATION = "Explanation"
+
+IDENTITY_COLUMNS = [
+    "filename",
+    "persona_name",
+    "run_id",
+    "judge_model",
+    "judge_instance",
+    "judge_id",
+]
+
+
+def answers_dir(evaluation_folder: Path | str) -> Path:
+    """Folder holding this run's per-question answer artifacts."""
+    return Path(evaluation_folder) / ANSWERS_DIR_NAME
+
+
+def conversation_answers_dir(evaluation_folder: Path | str) -> Path:
+    """Folder holding the per-conversation answer files."""
+    return answers_dir(evaluation_folder) / CONVERSATIONS_DIR_NAME
+
+
+def answers_tsv_path(evaluation_folder: Path | str) -> Path:
+    """Path of the run-level wide answers TSV."""
+    return answers_dir(evaluation_folder) / ANSWERS_TSV_NAME
+
+
+def answer_column(question_id: str) -> str:
+    """Wide-format column holding the answer to ``question_id``."""
+    return f"Q{question_id}"
+
+
+def explanation_column(question_id: str) -> str:
+    """Wide-format column holding the explanation for ``question_id``."""
+    return f"Q{question_id} explanation"
+
+
+def _flatten(text: Any) -> str:
+    """Collapse a value to a single TSV-safe cell."""
+    if text is None:
+        return ""
+    return str(text).replace("\t", " ").replace("\r", " ").replace("\n", " ").strip()
+
+
+def write_conversation_answers(
+    output_file: Path, question_log: Sequence[Dict[str, Any]], sep: str = "\t"
+) -> None:
+    """Write one conversation's visited questions in visit order.
+
+    ``question_log`` is the append-only record of questions asked, not
+    ``dimension_answers`` -- the latter is rewritten in place when a
+    ``NOT_RELEVANT>>`` goto fires, which drops the answers it replaces.
+    """
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write(f"{COL_QUESTION_ID}{sep}{COL_ANSWER}{sep}{COL_EXPLANATION}\n")
+        for entry in question_log:
+            question_id = _flatten(entry.get("question_id"))
+            answer = _flatten(entry.get("answer"))
+            explanation = _flatten(entry.get("reasoning"))
+            f.write(f"{question_id}{sep}{answer}{sep}{explanation}\n")
+
+
+def build_answers_dataframe(
+    evaluation_folder: Path | str, question_order: Sequence[str]
+) -> pd.DataFrame:
+    """Assemble the run-level wide answers table.
+
+    One row per per-conversation answer file, one ``Q{id}`` /
+    ``Q{id} explanation`` column pair per rubric question in ``question_order``.
+    Returns an empty (but correctly-columned) frame when the run has no answer
+    files, so callers can write it unconditionally.
+    """
+    columns: List[str] = list(IDENTITY_COLUMNS)
+    for question_id in question_order:
+        columns.append(answer_column(question_id))
+        columns.append(explanation_column(question_id))
+
+    folder = Path(evaluation_folder)
+    conversations_dir = conversation_answers_dir(folder)
+    if not conversations_dir.is_dir():
+        return pd.DataFrame(columns=columns)
+
+    run_id = folder.name.split("__")[-1] if "__" in folder.name else folder.name
+    known_questions = set(question_order)
+
+    rows: List[Dict[str, Any]] = []
+    for answer_file in sorted(conversations_dir.glob("*.tsv")):
+        try:
+            answers_df = pd.read_csv(
+                answer_file, sep="\t", dtype=str, keep_default_na=False
+            )
+        except Exception as e:  # noqa: BLE001 - one bad file must not sink the run
+            print(f"Warning: Error reading answers file {answer_file}: {e}")
+            continue
+
+        judge_model, judge_instance = parse_judge_metadata_from_evaluation_tsv_filename(
+            answer_file.name
+        )
+        conversation_filename = extract_conversation_filename_from_tsv(answer_file.name)
+        row: Dict[str, Any] = {column: "" for column in columns}
+        row.update(
+            {
+                "filename": conversation_filename,
+                "persona_name": extract_persona_name_from_filename(
+                    conversation_filename
+                )
+                or "",
+                "run_id": run_id,
+                "judge_model": judge_model,
+                "judge_instance": judge_instance,
+                "judge_id": max(0, judge_instance - 1),
+            }
+        )
+
+        for _, answer_row in answers_df.iterrows():
+            question_id = str(answer_row.get(COL_QUESTION_ID, "")).strip()
+            if not question_id or question_id not in known_questions:
+                # A rubric the run was not judged with, or a stray row.
+                continue
+            row[answer_column(question_id)] = str(
+                answer_row.get(COL_ANSWER, "")
+            ).strip()
+            row[explanation_column(question_id)] = str(
+                answer_row.get(COL_EXPLANATION, "")
+            ).strip()
+
+        rows.append(row)
+
+    return pd.DataFrame(rows, columns=columns)
+
+
+def write_answers_tsv(
+    evaluation_folder: Path | str, question_order: Sequence[str]
+) -> Path:
+    """Build and write ``answers/answers.tsv``; returns the path written."""
+    df = build_answers_dataframe(evaluation_folder, question_order)
+    out_path = answers_tsv_path(evaluation_folder)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(out_path, sep="\t", index=False)
+    return out_path

--- a/judge/llm_judge.py
+++ b/judge/llm_judge.py
@@ -5,6 +5,7 @@ import uuid
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from judge.answers import conversation_answers_dir, write_conversation_answers
 from judge.constants import BEST_PRACTICE, DAMAGING, NEUTRAL
 from judge.question_navigator import QuestionNavigator
 from judge.response_models import QuestionResponse
@@ -226,11 +227,17 @@ class LLMJudge:
                     raise ValueError("No questions found in rubric")
                 start_question_id = self.question_order[0]
             dimension_answers = {}
+            # Append-only record of every question actually asked, in visit
+            # order. dimension_answers cannot serve this purpose: a
+            # NOT_RELEVANT>> goto replaces a dimension's list wholesale (see
+            # _handle_not_relevant_goto), discarding the answers it overwrites
+            # -- including the answer that triggered the goto.
+            question_log: List[Dict[str, Any]] = []
 
             # this function returns if one of the questions triggered
             # 'Not Relevant' for all the remaining dimensions
             not_relevant_question_id = await self._ask_all_questions(
-                start_question_id, dimension_answers, verbose
+                start_question_id, dimension_answers, verbose, question_log
             )
 
             # Step 2: Calculate final scores
@@ -242,7 +249,12 @@ class LLMJudge:
             self._log_final_results(results)
             if auto_save:
                 self._save_results(
-                    conversation, output_folder, results, verbose, judge_instance
+                    conversation,
+                    output_folder,
+                    results,
+                    verbose,
+                    judge_instance,
+                    question_log,
                 )
 
             return results
@@ -360,6 +372,7 @@ class LLMJudge:
         results: Dict[str, Dict[str, str]],
         verbose: bool,
         judge_instance: Optional[int] = None,
+        question_log: Optional[List[Dict[str, Any]]] = None,
     ):
         """Save evaluation results to file.
 
@@ -369,6 +382,9 @@ class LLMJudge:
             results: Evaluation results dictionary
             verbose: Whether to print progress
             judge_instance: Optional judge instance number for filename
+            question_log: Questions asked, in visit order. When given, the
+                per-question answers are written alongside the evaluation as
+                answers/conversations/<tsv stem>.tsv
         """
         filename = conversation.metadata.get("filename", "unknown.txt")
         tsv_name = judge_evaluation_tsv_filename(
@@ -380,11 +396,17 @@ class LLMJudge:
         self._save_iterative_evaluation(results, output_file)
         self.logger.info(f"Results saved to: {output_file}")
 
+        if question_log is not None:
+            answers_file = conversation_answers_dir(output_folder) / tsv_name
+            write_conversation_answers(answers_file, question_log)
+            self.logger.info(f"Per-question answers saved to: {answers_file}")
+
     async def _ask_all_questions(
         self,
         start_question_id: str,
         dimension_answers: Dict[str, List[Dict[str, Any]]],
         verbose: bool = False,
+        question_log: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[str]:
         """
         Navigate through all questions until END/ASSIGN_END or completion.
@@ -401,6 +423,10 @@ class LLMJudge:
             dimension_answers: Dictionary to track answers by dimension
                 (modified in place)
             verbose: Whether to print progress
+            question_log: Optional append-only list collecting every question
+                asked, in visit order (modified in place). Unlike
+                dimension_answers it is never rewritten, so it survives
+                NOT_RELEVANT>> and ASSIGN_END handling.
 
         Returns:
             Question ID that triggered "Not Relevant" for all dimensions, or None
@@ -451,6 +477,16 @@ class LLMJudge:
                 dimension or current_dimension,
                 reasoning,
             )
+            if question_log is not None:
+                question_log.append(
+                    {
+                        "question_id": current_question_id,
+                        "dimension": dimension or current_dimension,
+                        "answer": answer_text,
+                        "severity": question_data.get("severity"),
+                        "reasoning": reasoning,
+                    }
+                )
 
             # Step 3: Determine next question
             next_question_id, goto_value = self.navigator.get_next_question(

--- a/judge/runner.py
+++ b/judge/runner.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union, cast
 
 import pandas as pd
 
+from .answers import conversation_answers_dir, write_answers_tsv
 from .llm_judge import LLMJudge
 from .rubric_config import ConversationData, RubricConfig
 from .score_utils import build_dataframe_from_tsv_files
@@ -673,6 +674,16 @@ async def judge_conversations(
             pd.DataFrame(results, columns=cast(Any, columns)).to_csv(
                 out_csv, index=False
             )
+
+        # Run-level per-question answers, rebuilt from the per-conversation
+        # files the same way results.csv is rebuilt from evaluation TSVs, so
+        # --resume includes conversations this batch skipped.
+        if conversation_answers_dir(output_folder).is_dir():
+            answers_path = write_answers_tsv(
+                output_folder, rubric_config.question_order
+            )
+            if verbose:
+                print(f"📝 Per-question answers written to: {answers_path}")
     if verbose:
         elapsed_s = (datetime.now() - batch_start).total_seconds()
         print(

--- a/tests/integration/test_evaluation_runner.py
+++ b/tests/integration/test_evaluation_runner.py
@@ -16,6 +16,12 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
+from judge.answers import (
+    answer_column,
+    answers_tsv_path,
+    conversation_answers_dir,
+    explanation_column,
+)
 from judge.rubric_config import ConversationData, RubricConfig, load_conversations
 from judge.runner import (
     batch_evaluate_with_individual_judges,
@@ -480,6 +486,70 @@ class TestJudgeConversations:
         assert "run_id" in df.columns
         assert "judge_model" in df.columns
         assert "judge_instance" in df.columns
+
+    async def test_judge_conversations_writes_per_question_answers(
+        self,
+        tmp_path: Path,
+        mock_rubric_files: str,
+        mock_llm_factory_for_judge,
+    ):
+        """The run writes answers/answers.tsv beside results.csv.
+
+        Arrange: two conversations
+        Act: judge_conversations
+        Assert: one wide answers row per conversation, rubric-ordered question
+        columns, and nothing stray in the evaluation folder's own *.tsv glob
+        """
+        conv_folder = tmp_path / "conversations"
+        conv_folder.mkdir()
+        (conv_folder / "conv1.txt").write_text(
+            "user: Hello\nchatbot: Hi there", encoding="utf-8"
+        )
+        (conv_folder / "conv2.txt").write_text(
+            "user: How are you?\nchatbot: I'm well", encoding="utf-8"
+        )
+
+        output_root = str(tmp_path / "evaluation_output")
+        conversations = await load_conversations(str(conv_folder))
+        rubric_config = await RubricConfig.load(
+            rubric_folder=mock_rubric_files,
+            rubric_file="rubric.tsv",
+            rubric_prompt_beginning_file="rubric_prompt_beginning.txt",
+            question_prompt_file="question_prompt.txt",
+        )
+
+        await judge_conversations(
+            judge_models={"mock-judge": 1},
+            conversations=conversations,
+            rubric_config=rubric_config,
+            output_root=output_root,
+            conversation_folder_name="conversations",
+            verbose=False,
+            save_aggregated_results=True,
+        )
+
+        output_folder = next(Path(output_root).glob("j_mock-judgex1_*"))
+
+        answers_tsv = answers_tsv_path(output_folder)
+        assert answers_tsv.exists()
+
+        df = pd.read_csv(answers_tsv, sep="\t", keep_default_na=False)
+        assert len(df) == len(conversations)
+        for question_id in rubric_config.question_order:
+            assert answer_column(question_id) in df.columns
+            assert explanation_column(question_id) in df.columns
+
+        # Every conversation was asked the first rubric question.
+        first_question = answer_column(rubric_config.question_order[0])
+        assert all(answer != "" for answer in df[first_question])
+
+        # A per-conversation file exists for each evaluation TSV.
+        eval_tsvs = {p.name for p in output_folder.glob("*.tsv")}
+        per_conversation = {
+            p.name for p in conversation_answers_dir(output_folder).glob("*.tsv")
+        }
+        assert per_conversation == eval_tsvs
+        assert "answers.tsv" not in eval_tsvs
 
     async def test_results_csv_matches_tsv_reconstruction(
         self,

--- a/tests/unit/judge/test_answers.py
+++ b/tests/unit/judge/test_answers.py
@@ -1,0 +1,264 @@
+"""Unit tests for judge/answers.py — per-question answer artifacts.
+
+Covers the per-conversation long-format file, the run-level wide aggregate
+(rubric-ordered columns, blanks for unvisited questions), and the reason the
+visit log exists at all: dimension_answers is rewritten in place by
+NOT_RELEVANT>> handling and cannot be used as the source.
+"""
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from judge.answers import (
+    ANSWERS_TSV_NAME,
+    answer_column,
+    answers_tsv_path,
+    build_answers_dataframe,
+    conversation_answers_dir,
+    explanation_column,
+    write_answers_tsv,
+    write_conversation_answers,
+)
+from judge.llm_judge import LLMJudge
+
+# Opaque, non-lexical IDs: sorting these as strings gives 1, 10, 2 — the
+# aggregate must follow rubric order instead.
+QUESTION_ORDER = ["1", "2", "9", "10", "1a"]
+
+EVAL_TSV_NAME = "abc123_Brian_gpt-5_run1_mock-llm_i1.tsv"
+
+
+def _log(*pairs):
+    return [
+        {"question_id": qid, "answer": answer, "reasoning": f"why {qid}"}
+        for qid, answer in pairs
+    ]
+
+
+@pytest.mark.unit
+class TestWriteConversationAnswers:
+    """Test the per-conversation long-format file."""
+
+    def test_writes_header_and_one_row_per_visited_question(self, tmp_path: Path):
+        out = tmp_path / "answers" / "conversations" / EVAL_TSV_NAME
+        write_conversation_answers(out, _log(("1", "Yes"), ("9", "Immediate risk")))
+
+        lines = out.read_text(encoding="utf-8").splitlines()
+        assert lines[0] == "Question ID\tAnswer\tExplanation"
+        assert lines[1] == "1\tYes\twhy 1"
+        assert lines[2] == "9\tImmediate risk\twhy 9"
+        assert len(lines) == 3
+
+    def test_preserves_visit_order(self, tmp_path: Path):
+        out = tmp_path / "a.tsv"
+        write_conversation_answers(out, _log(("9", "A"), ("1", "B"), ("10", "C")))
+
+        ids = [line.split("\t")[0] for line in out.read_text().splitlines()[1:]]
+        assert ids == ["9", "1", "10"]
+
+    def test_flattens_tabs_and_newlines_in_explanation(self, tmp_path: Path):
+        out = tmp_path / "a.tsv"
+        write_conversation_answers(
+            out,
+            [
+                {
+                    "question_id": "1",
+                    "answer": "Yes",
+                    "reasoning": "line one\nline\ttwo\r\nline three",
+                }
+            ],
+        )
+
+        lines = out.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2, "explanation must not spill across rows"
+        assert lines[1].count("\t") == 2, "explanation must not add columns"
+        assert lines[1] == "1\tYes\tline one line two  line three"
+
+    def test_empty_log_writes_header_only(self, tmp_path: Path):
+        out = tmp_path / "a.tsv"
+        write_conversation_answers(out, [])
+        assert out.read_text(encoding="utf-8").splitlines() == [
+            "Question ID\tAnswer\tExplanation"
+        ]
+
+
+@pytest.mark.unit
+class TestBuildAnswersDataframe:
+    """Test the run-level wide aggregate."""
+
+    def _eval_folder(self, tmp_path: Path) -> Path:
+        folder = (
+            tmp_path / "j_mockx1_20260101_000000__p_x__a_y__t1__r1__20260101_000000"
+        )
+        folder.mkdir(parents=True)
+        return folder
+
+    def test_columns_follow_rubric_order_not_sort_order(self, tmp_path: Path):
+        folder = self._eval_folder(tmp_path)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME, _log(("1", "Yes"))
+        )
+
+        df = build_answers_dataframe(folder, QUESTION_ORDER)
+
+        question_columns = [c for c in df.columns if c.startswith("Q")]
+        assert question_columns == [
+            "Q1",
+            "Q1 explanation",
+            "Q2",
+            "Q2 explanation",
+            "Q9",
+            "Q9 explanation",
+            "Q10",
+            "Q10 explanation",
+            "Q1a",
+            "Q1a explanation",
+        ]
+
+    def test_one_row_per_conversation_with_identity_columns(self, tmp_path: Path):
+        folder = self._eval_folder(tmp_path)
+        answers = conversation_answers_dir(folder)
+        write_conversation_answers(answers / EVAL_TSV_NAME, _log(("1", "Yes")))
+        write_conversation_answers(
+            answers / "def456_Dana_gpt-5_run2_mock-llm_i1.tsv", _log(("1", "No"))
+        )
+
+        df = build_answers_dataframe(folder, QUESTION_ORDER)
+
+        assert len(df) == 2
+        assert sorted(df["filename"]) == [
+            "abc123_Brian_gpt-5_run1.txt",
+            "def456_Dana_gpt-5_run2.txt",
+        ]
+        assert sorted(df["persona_name"]) == ["Brian", "Dana"]
+        assert set(df["judge_model"]) == {"mock-llm"}
+        assert set(df["judge_instance"]) == {1}
+        assert set(df["judge_id"]) == {0}
+        assert set(df["run_id"]) == {"20260101_000000"}
+
+    def test_unvisited_questions_are_blank(self, tmp_path: Path):
+        folder = self._eval_folder(tmp_path)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME,
+            _log(("1", "Yes"), ("9", "Immediate risk")),
+        )
+
+        row = build_answers_dataframe(folder, QUESTION_ORDER).iloc[0]
+
+        assert row[answer_column("1")] == "Yes"
+        assert row[explanation_column("1")] == "why 1"
+        assert row[answer_column("9")] == "Immediate risk"
+        # Q2, Q10 and Q1a were never reached by this conversation's flow.
+        for question_id in ("2", "10", "1a"):
+            assert row[answer_column(question_id)] == ""
+            assert row[explanation_column(question_id)] == ""
+
+    def test_question_not_in_rubric_is_ignored(self, tmp_path: Path):
+        folder = self._eval_folder(tmp_path)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME,
+            _log(("1", "Yes"), ("999", "from another rubric")),
+        )
+
+        df = build_answers_dataframe(folder, QUESTION_ORDER)
+
+        assert "Q999" not in df.columns
+        assert df.iloc[0][answer_column("1")] == "Yes"
+
+    def test_missing_answers_folder_yields_empty_but_columned_frame(
+        self, tmp_path: Path
+    ):
+        df = build_answers_dataframe(self._eval_folder(tmp_path), QUESTION_ORDER)
+
+        assert df.empty
+        assert answer_column("9") in df.columns
+        assert explanation_column("9") in df.columns
+
+    def test_write_answers_tsv_round_trips(self, tmp_path: Path):
+        folder = self._eval_folder(tmp_path)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME,
+            _log(("1", "Yes"), ("9", "Immediate risk")),
+        )
+
+        out_path = write_answers_tsv(folder, QUESTION_ORDER)
+
+        assert out_path == answers_tsv_path(folder)
+        assert out_path.name == ANSWERS_TSV_NAME
+        df = pd.read_csv(out_path, sep="\t", keep_default_na=False)
+        assert len(df) == 1
+        assert df.iloc[0]["Q9"] == "Immediate risk"
+        assert df.iloc[0]["Q9 explanation"] == "why 9"
+
+    def test_aggregate_is_not_mistaken_for_an_evaluation_tsv(self, tmp_path: Path):
+        """Both artifacts sit below the evaluation folder, not inside it.
+
+        build_results_csv_from_tsv_files globs *.tsv directly in the evaluation
+        folder, and judge.runner's resume scan does the same, so a stray TSV
+        there would be read as an evaluation.
+        """
+        folder = self._eval_folder(tmp_path)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME, _log(("1", "Yes"))
+        )
+        write_answers_tsv(folder, QUESTION_ORDER)
+
+        assert list(folder.glob("*.tsv")) == []
+
+
+@pytest.mark.unit
+class TestVisitLogSurvivesNotRelevantGoto:
+    """The reason the visit log is not sourced from dimension_answers."""
+
+    async def test_not_relevant_goto_clobbers_dimension_answers(
+        self, rubric_config_factory
+    ):
+        """_handle_not_relevant_goto replaces a dimension's whole answer list.
+
+        A question whose GOTO is NOT_RELEVANT>> therefore erases its own
+        recorded answer, which is exactly the answer an per-question artifact
+        needs to keep.
+        """
+        rubric_config = await rubric_config_factory(rubric_file="rubric_simple.tsv")
+        judge = LLMJudge(judge_model="mock-llm", rubric_config=rubric_config)
+        dimension = rubric_config.question_flow_data[rubric_config.question_order[0]][
+            "dimension"
+        ]
+
+        dimension_answers = {
+            dimension: [
+                {
+                    "question_id": "9",
+                    "question": "Select one of the following:",
+                    "answer": "No suicidal thoughts present",
+                    "severity": None,
+                    "reasoning": "No indication of suicidal thoughts.",
+                }
+            ]
+        }
+
+        judge._handle_not_relevant_goto(
+            "9", "No suicidal thoughts present", dimension, dimension_answers, False
+        )
+
+        surviving = dimension_answers[dimension]
+        assert len(surviving) == 1
+        assert surviving[0]["answer"] == "Not Relevant"
+        assert all(
+            entry["answer"] != "No suicidal thoughts present" for entry in surviving
+        ), "Q9's real answer is gone from dimension_answers"
+
+    def test_visit_log_retains_the_answer(self, tmp_path: Path):
+        """The append-only log is never rewritten, so the answer persists."""
+        folder = tmp_path / "j_mockx1_20260101_000000__run__20260101_000000"
+        folder.mkdir(parents=True)
+        write_conversation_answers(
+            conversation_answers_dir(folder) / EVAL_TSV_NAME,
+            _log(("9", "No suicidal thoughts present")),
+        )
+
+        row = build_answers_dataframe(folder, QUESTION_ORDER).iloc[0]
+
+        assert row[answer_column("9")] == "No suicidal thoughts present"


### PR DESCRIPTION
## Problem

The evaluation TSV a judge run writes is dimension-level — five rows of `Dimension / Score / Reasoning`. The individual rubric answers behind those scores are collapsed away and discarded, so *"what did the judge answer for question N?"* is only recoverable by grepping `logs/*.log` for `--- Question N ---` / `MATCHED ANSWER:`. That's forensics, not a data source.

`results.csv` narrows further: it keeps one `{dimension}_yes_question_id` per dimension, regex-extracted from the reasoning prose, and only for questions that answered `Yes` **and** carry a severity. Questions with no severity — including the risk-classification question — never surface anywhere.

## What this adds

Two artifacts under an `answers/` subfolder of the evaluation folder:

```
<evaluation folder>/
  results.csv
  <conversation>_<judge>_i1.tsv          # existing, dimension-level
  logs/
  answers/
    answers.tsv                          # NEW — run-level, wide
    conversations/
      <conversation>_<judge>_i1.tsv      # NEW — per conversation, long
```

**`answers/answers.tsv`** — one row per conversation, a `Q{id}` / `Q{id} explanation` column pair per rubric question, in rubric order:

| filename | persona_name | … | Q1 | Q1 explanation | Q9 | Q9 explanation | Q10 |
|---|---|---|---|---|---|---|---|
| `abc123_Brian_gpt-5_run1.txt` | Brian | … | Yes | The user describes… | Immediate risk | Weapon mentioned… | |

Questions the flow skipped are blank, so a row also shows **which branch** the conversation took.

**`answers/conversations/<stem>.tsv`** — long format, one row per visited question in visit order. This is what makes the aggregate resume-safe: it's rebuilt from these files exactly the way `results.csv` is rebuilt from evaluation TSVs, so `--resume` includes conversations a batch skipped.

## Three things worth reviewing

**1. The source is a new append-only visit log, not `dimension_answers`.** `dimension_answers` cannot serve: `_handle_not_relevant_goto` does `dimension_answers[current_dimension] = [...]`, replacing a dimension's whole list with one synthetic marker. A question whose `GOTO` is `NOT_RELEVANT>>` therefore erases **its own** recorded answer, plus every earlier answer in that dimension. In `data/SI/rubric.tsv` that's Q9's `No suicidal thoughts present` branch — the answer you'd most want recorded. `TestVisitLogSurvivesNotRelevantGoto` pins that behaviour so the distinction isn't lost later.

**2. Both artifacts live in a subfolder, deliberately.** `build_results_csv_from_tsv_files` globs `*.tsv` directly in the evaluation folder, and `judge.runner`'s resume scan (`_list_existing_evaluation_tsv_basenames`) does the same. A TSV placed there would be parsed as an evaluation and produce a junk `results.csv` row. A test asserts `list(folder.glob("*.tsv")) == []` for the new files.

**3. Column order comes from `RubricConfig.question_order`, not sorting.** Question IDs are opaque strings — one rubric uses `1a`-style IDs, and lexical sort would give `1, 10, 11, … 2, 20`.

## Cost

Measured on a real 100-conversation run: median 26 questions visited, mean explanation 479 chars → ~12 KB/conversation, **~1.2 MB per run**. The `logs/` directory for the same run is already 12 MB.

## Scope

Purely additive. `results.csv`, the evaluation TSVs, and all scoring are untouched; nothing reads the new files yet. Explanations are flattened (tabs, newlines, CRs → spaces) so rows can't spill across lines.

## Tests

13 unit tests in `tests/unit/judge/test_answers.py` (per-conversation format and flattening, rubric-vs-sort column order, blanks for unvisited questions, unknown-question-ID tolerance, missing-folder returns an empty-but-columned frame, round trip, glob isolation, the `NOT_RELEVANT>>` regression) plus one runner integration test asserting the aggregate appears beside `results.csv` with one row per conversation.

`uv run pytest -m "not live"` → 1052 passed, coverage 75%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)